### PR TITLE
docs: remind us to sync Fly hard_limit and PG max

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -21,6 +21,7 @@ processes = []
   protocol = "tcp"
   script_checks = []
   [services.concurrency]
+    # Remember to update PG Pool config option `max` in bin/spark-stats.js when changing `hard_limit`.
     hard_limit = 800
     soft_limit = 600
     type = "connections"


### PR DESCRIPTION
See https://github.com/filecoin-station/spark-stats/pull/2#discussion_r1452752585

