### PR TITLE
fix: handle request paths starting with //

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -32,7 +32,9 @@ export const createHandler = ({
  * @param {import('pg').Pool} pgPool
  */
 const handler = async (req, res, pgPool) => {
-  const { pathname, searchParams } = new URL(req.url, 'http://127.0.0.1')
+  // Fix the edge case: new URL('//foo', 'http://127.0.0.1') produces href "http://foo/"
+  const reqUrl = req.url.replace(/^\/+/, '/')
+  const { pathname, searchParams } = new URL(reqUrl, 'http://127.0.0.1')
   const segs = pathname.split('/').filter(Boolean)
   if (req.method === 'GET' && segs[0] === 'retrieval-success-rate' && segs.length === 1) {
     await getStatsWithFilterAndCaching(

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -51,6 +51,11 @@ describe('HTTP request handler', () => {
     await assertResponseStatus(res, 404)
   })
 
+  it('returns 404 when the path starts with double slash', async () => {
+    const res = await fetch(`${baseUrl}//path-not-found`)
+    await assertResponseStatus(res, 404)
+  })
+
   describe('GET /retrieval-success-rate', () => {
     beforeEach(async () => {
       await pgPool.query('DELETE FROM retrieval_stats')


### PR DESCRIPTION
Calling `new URL('//foo', 'http://127.0.0.1')` produces href `http://foo/`. As a result, we were treating all requests for paths starting with double slash as if no path was specified.

Links:
- https://github.com/filecoin-station/roadmap/issues/57
