### PR TITLE
feat: setup CORS to allow all origins

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -86,6 +86,8 @@ export const today = () => getDayAsISOString(new Date())
  * @param {(import('pg').Pool, import('./typings').Filter) => Promise<object[]>} fetchStatsFn
  */
 const getStatsWithFilterAndCaching = async (pathname, searchParams, res, pgPool, fetchStatsFn) => {
+  res.setHeader('access-control-allow-origin', '*')
+
   let from = searchParams.get('from')
   let to = searchParams.get('to')
   let shouldRedirect = false


### PR DESCRIPTION
This allows single-page applications to query our stats. I thought I would need this for our public Grafana Dashboard, so that it can fetch data from the browser. At the end, I found a different option, so this is not strictly needed. But it can be useful as it allows our community to build their own visualisations from our stats.