### PR TITLE
refactor: simplify handling of '//' in req.url

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -32,9 +32,8 @@ export const createHandler = ({
  * @param {import('pg').Pool} pgPool
  */
 const handler = async (req, res, pgPool) => {
-  // Fix the edge case: new URL('//foo', 'http://127.0.0.1') produces href "http://foo/"
-  const reqUrl = req.url.replace(/^\/+/, '/')
-  const { pathname, searchParams } = new URL(reqUrl, 'http://127.0.0.1')
+  // Caveat! `new URL('//foo', 'http://127.0.0.1')` would produce "http://foo/" - not what we want!
+  const { pathname, searchParams } = new URL(`http://127.0.0.1${req.url}`)
   const segs = pathname.split('/').filter(Boolean)
   if (req.method === 'GET' && segs[0] === 'retrieval-success-rate' && segs.length === 1) {
     await getStatsWithFilterAndCaching(


### PR DESCRIPTION
Per the discussion in https://github.com/filecoin-station/spark-stats/pull/6#discussion_r1454930123
