### PR TITLE
feat: rename `/miners` to `/storage-providers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 API exposing public statistics about Spark
 
+## Public API
+
+Base URL: http://stats.filspark.com/
+
+- `GET /storage-providers/retrieval-success-rate/summary?from=<day>&to=<day>`
+
+  http://stats.filspark.com/storage-providers/retrieval-success-rate/summary
+
 ## Development
 
 ### Database

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -61,7 +61,13 @@ const handler = async (req, res, pgPool) => {
       res,
       pgPool,
       fetchMonthlyParticipants)
-  } else if (req.method === 'GET' && segs.join('/') === 'miners/retrieval-success-rate/summary') {
+  } else if (req.method === 'GET' && segs[0] === 'miners') {
+    // Redirect URLs starting with `/miners/` to the new location starting with `/storage-providers/`
+    segs[0] = 'storage-providers'
+    res.setHeader('location', `/${segs.join('/')}?${searchParams}`)
+    res.writeHead(301) // Moved Permanently
+    res.end()
+  } else if (req.method === 'GET' && segs.join('/') === 'storage-providers/retrieval-success-rate/summary') {
     await getStatsWithFilterAndCaching(
       pathname,
       searchParams,

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -217,7 +217,26 @@ describe('HTTP request handler', () => {
   })
 
   describe('GET /miners/retrieval-success-rate/summary', () => {
-    it('returns a summary of miners RSR for the given date range', async () => {
+    it('returns a redirect to /storage-providers/retrieval-success-rate/summary', async () => {
+      const res = await fetch(
+        new URL(
+          '/miners/retrieval-success-rate/summary?from=2024-01-10&to=2024-01-15',
+          baseUrl
+        ), {
+          redirect: 'manual'
+        }
+      )
+
+      await assertResponseStatus(res, 301)
+      assert.strictEqual(
+        res.headers.get('location'),
+        '/storage-providers/retrieval-success-rate/summary?from=2024-01-10&to=2024-01-15'
+      )
+    })
+  })
+
+  describe('GET /storage-providers/retrieval-success-rate/summary', () => {
+    it('returns a summary of RSR for the given date range', async () => {
       // before the range
       await givenRetrievalStats(pgPool, { day: '2024-01-10', minerId: 'f1one', total: 10, successful: 1 })
       await givenRetrievalStats(pgPool, { day: '2024-01-10', minerId: 'f1two', total: 100, successful: 20 })
@@ -230,7 +249,7 @@ describe('HTTP request handler', () => {
 
       const res = await fetch(
         new URL(
-          '/miners/retrieval-success-rate/summary?from=2024-01-11&to=2024-01-11',
+          '/storage-providers/retrieval-success-rate/summary?from=2024-01-11&to=2024-01-11',
           baseUrl
         ), {
           redirect: 'manual'


### PR DESCRIPTION
- **feat: rename `/miners` to `/retrieval-providers`**
- **docs: document RSR summary endpoint**

As requested by @PatrickWoodhead in https://space-meridian.slack.com/archives/C06SUTD79NY/p1713361095204799?thread_ts=1713360225.913109&cid=C06SUTD79NY
