### PR TITLE
feat: sort items in responses by date

### DIFF
--- a/lib/stats-fetchers.js
+++ b/lib/stats-fetchers.js
@@ -10,6 +10,7 @@ export const fetchRetrievalSuccessRate = async (pgPool, filter) => {
     FROM retrieval_stats
     WHERE day >= $1 AND day <= $2
     GROUP BY day
+    ORDER BY day
     `, [
     filter.from,
     filter.to
@@ -33,6 +34,7 @@ export const fetchDailyParticipants = async (pgPool, filter) => {
     FROM daily_participants
     WHERE day >= $1 AND day <= $2
     GROUP BY day
+    ORDER BY day
     `, [
     filter.from,
     filter.to
@@ -56,6 +58,7 @@ export const fetchMonthlyParticipants = async (pgPool, filter) => {
       day >= date_trunc('month', $1::DATE)
       AND day < date_trunc('month', $2::DATE) + INTERVAL '1 month'
     GROUP BY month
+    ORDER BY month
     `, [
     filter.from,
     filter.to

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -155,10 +155,30 @@ describe('HTTP request handler', () => {
       await assertResponseStatus(res, 200)
       /** @type {{ day: string, success_rate: number }[]} */
       const stats = await res.json()
-      stats.sort((a, b) => new Date(a.day) - new Date(b.day))
       assert.deepStrictEqual(stats, [
         { day: '2024-01-10', success_rate: 51 / 110 },
         { day: '2024-01-11', success_rate: 61 / 220 }
+      ])
+    })
+
+    it('sorts items by date ascending', async () => {
+      await givenRetrievalStats(pgPool, { day: '2024-01-20', total: 10, successful: 1 })
+      await givenRetrievalStats(pgPool, { day: '2024-01-10', total: 10, successful: 5 })
+
+      const res = await fetch(
+        new URL(
+          '/retrieval-success-rate?from=2024-01-01&to=2024-01-31',
+          baseUrl
+        ), {
+          redirect: 'manual'
+        }
+      )
+      await assertResponseStatus(res, 200)
+      /** @type {{ day: string, success_rate: number }[]} */
+      const stats = await res.json()
+      assert.deepStrictEqual(stats, [
+        { day: '2024-01-10', success_rate: 5 / 10 },
+        { day: '2024-01-20', success_rate: 1 / 10 }
       ])
     })
   })


### PR DESCRIPTION
Before this change, daily RSR was sorted randomly, which caused our public dashboard to pick a wrong RSR value (we configured Grafana to use the Last item).

I was able to write a failing test only for one of the SQL queries (stats endpoints). The remaining changes are not covered by tests.
