### PR TITLE
feat: expose "total" and "successful" for RSR

### DIFF
--- a/stats/bin/migrate.js
+++ b/stats/bin/migrate.js
@@ -5,8 +5,8 @@ import {
 import { migrateWithPgConfig as migrateEvaluateDB } from 'spark-evaluate/lib/migrate.js'
 import { migrateWithPgConfig as migrateStatsDB } from '@filecoin-station/spark-stats-db-migrations'
 
-console.log('Migrating spark_evaluate database')
+console.log('Migrating spark_evaluate database', EVALUATE_DB_URL)
 await migrateEvaluateDB({ connectionString: EVALUATE_DB_URL })
 
-console.log('Migrating spark_stats database')
+console.log('Migrating spark_stats database', DATABASE_URL)
 await migrateStatsDB({ connectionString: DATABASE_URL })

--- a/stats/lib/stats-fetchers.js
+++ b/stats/lib/stats-fetchers.js
@@ -19,6 +19,8 @@ export const fetchRetrievalSuccessRate = async (pgPool, filter) => {
   ])
   const stats = rows.map(r => ({
     day: r.day,
+    total: r.total,
+    successful: r.successful,
     success_rate: r.total > 0 ? r.successful / r.total : null
   }))
   return stats
@@ -128,6 +130,8 @@ export const fetchMinersRSRSummary = async (pgPool, filter) => {
   ])
   const stats = rows.map(r => ({
     miner_id: r.miner_id,
+    total: r.total,
+    successful: r.successful,
     success_rate: r.total > 0 ? r.successful / r.total : null
   }))
   return stats

--- a/stats/test/handler.test.js
+++ b/stats/test/handler.test.js
@@ -78,7 +78,7 @@ describe('HTTP request handler', () => {
       await assertResponseStatus(res, 200)
       const stats = await res.json()
       assert.deepStrictEqual(stats, [
-        { day, success_rate: 0.1 }
+        { day, success_rate: 0.1, successful: '1', total: '10' }
       ])
     })
 
@@ -99,8 +99,8 @@ describe('HTTP request handler', () => {
       await assertResponseStatus(res, 200)
       const stats = await res.json()
       assert.deepStrictEqual(stats, [
-        { day: '2024-01-11', success_rate: 0.05 },
-        { day: '2024-01-12', success_rate: 0.1 }
+        { day: '2024-01-11', success_rate: 0.05, successful: '1', total: '20' },
+        { day: '2024-01-12', success_rate: 0.1, successful: '3', total: '30' }
       ])
     })
 
@@ -160,8 +160,8 @@ describe('HTTP request handler', () => {
       /** @type {{ day: string, success_rate: number }[]} */
       const stats = await res.json()
       assert.deepStrictEqual(stats, [
-        { day: '2024-01-10', success_rate: 51 / 110 },
-        { day: '2024-01-11', success_rate: 61 / 220 }
+        { day: '2024-01-10', success_rate: 51 / 110, total: '110', successful: '51' },
+        { day: '2024-01-11', success_rate: 61 / 220, total: '220', successful: '61' }
       ])
     })
 
@@ -181,8 +181,8 @@ describe('HTTP request handler', () => {
       /** @type {{ day: string, success_rate: number }[]} */
       const stats = await res.json()
       assert.deepStrictEqual(stats, [
-        { day: '2024-01-10', success_rate: 5 / 10 },
-        { day: '2024-01-20', success_rate: 1 / 10 }
+        { day: '2024-01-10', success_rate: 5 / 10, total: '10', successful: '5' },
+        { day: '2024-01-20', success_rate: 1 / 10, total: '10', successful: '1' }
       ])
     })
   })
@@ -343,8 +343,8 @@ describe('HTTP request handler', () => {
       await assertResponseStatus(res, 200)
       const stats = await res.json()
       assert.deepStrictEqual(stats, [
-        { miner_id: 'f1one', success_rate: 0.05 },
-        { miner_id: 'f1two', success_rate: 0.75 }
+        { miner_id: 'f1one', success_rate: 0.05, total: '20', successful: '1' },
+        { miner_id: 'f1two', success_rate: 0.75, total: '200', successful: '150' }
       ])
     })
   })


### PR DESCRIPTION
Improve the following two endpoints to return the number of all checks
and the number of successful checks that were used to calculate RSR.
This enables consumers to filter out some data points and still be able
to correctly calculate aggregated RSR.

- `/miners/retrieval-success-rate/summary`
- `/retrieval-success-rate`
