### PR TITLE
chore: bump spark-evaluate from 534454 to 2a9546

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5311,14 +5311,13 @@
       }
     },
     "node_modules/spark-evaluate": {
-      "resolved": "git+ssh://git@github.com/filecoin-station/spark-evaluate.git#534454c9b2323b67d50b159a3504de8a06eedcb2",
-      "integrity": "sha512-KFIA5F8Lw/+I+2MzPKT6qsgtt5LNSqdbuk9/LUTUyduGSUpQj++TCI+PlvSs2mTRQz7dZCQcXhhY5cchj7n1vA==",
+      "resolved": "git+ssh://git@github.com/filecoin-station/spark-evaluate.git#2a9546f7fee00da63cded76478a2a9c1bb3704c3",
       "dependencies": {
         "@filecoin-station/spark-impact-evaluator": "^1.1.1",
         "@glif/filecoin-address": "^3.0.5",
         "@influxdata/influxdb-client": "^1.33.2",
         "@ipld/car": "^5.3.1",
-        "@sentry/node": "^8.9.1",
+        "@sentry/node": "^8.9.2",
         "@web3-storage/car-block-validator": "^1.2.0",
         "debug": "^4.3.5",
         "ethers": "^6.10.0",


### PR DESCRIPTION
It seems that Dependabot is no longer able to update this git-based dependency
after we introduced the monorepo layout in #118.

See e.g. this log: https://github.com/filecoin-station/spark-stats/network/updates/841403106
```
updater | 2024/06/13 07:24:55 INFO <job_841403106> Updating spark-evaluate from 534454c9b2323b67d50b159a3504de8a06eedcb2 to 9e175400652623f19569eecfd97706a77084ff36
updater | 2024/06/13 07:24:55 ERROR <job_841403106> Error processing spark-evaluate (Dependabot::NpmAndYarn::FileUpdater::NoChangeError)
updater | 2024/06/13 07:24:55 ERROR <job_841403106> No files were updated!
updater | 2024/06/13 07:24:55 ERROR <job_841403106> 
````
