### PR TITLE
stats: refactor path handling

### DIFF
--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -84,6 +84,9 @@ const handler = async (req, res, pgPools) => {
     await respond(fetchMinersRSRSummary)
   } else if (await handlePlatformRoutes(req, res, pgPools)) {
     // no-op, request was handled by handlePlatformRoute
+  } else if (req.method === 'GET' && pathname === '/') {
+    // health check - required by Grafana datasources
+    res.end('OK')
   } else {
     notFound(res)
   }

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -43,6 +43,16 @@ const enableCors = (req, res) => {
   }
 }
 
+const respondWithFetchFn = (pathname, searchParams, res, pgPools) => fetchFn => {
+  return getStatsWithFilterAndCaching(
+    pathname,
+    searchParams,
+    res,
+    pgPools,
+    fetchFn
+  )
+}
+
 /**
  * @param {import('node:http').IncomingMessage} req
  * @param {import('node:http').ServerResponse} res
@@ -51,29 +61,24 @@ const enableCors = (req, res) => {
 const handler = async (req, res, pgPools) => {
   // Caveat! `new URL('//foo', 'http://127.0.0.1')` would produce "http://foo/" - not what we want!
   const { pathname, searchParams } = new URL(`http://127.0.0.1${req.url}`)
-  const segs = pathname.split('/').filter(Boolean)
 
   enableCors(req, res)
+  const respond = respondWithFetchFn(pathname, searchParams, res, pgPools)
 
-  const fetchFunctionMap = {
-    'deals/daily': fetchDailyDealStats,
-    'retrieval-success-rate': fetchRetrievalSuccessRate,
-    'participants/daily': fetchDailyParticipants,
-    'participants/monthly': fetchMonthlyParticipants,
-    'participants/change-rates': fetchParticipantChangeRates,
-    'participants/scheduled-rewards/daily': fetchParticipantScheduledRewards,
-    'miners/retrieval-success-rate/summary': fetchMinersRSRSummary
-  }
-
-  const fetchStatsFn = fetchFunctionMap[segs.join('/')]
-  if (req.method === 'GET' && fetchStatsFn) {
-    await getStatsWithFilterAndCaching(
-      pathname,
-      searchParams,
-      res,
-      pgPools,
-      fetchStatsFn
-    )
+  if (req.method === 'GET' && pathname === '/deals/daily') {
+    await respond(fetchDailyDealStats)
+  } else if (req.method === 'GET' && pathname === '/retrieval-success-rate') {
+    await respond(fetchRetrievalSuccessRate)
+  } else if (req.method === 'GET' && pathname === '/participants/daily') {
+    await respond(fetchDailyParticipants)
+  } else if (req.method === 'GET' && pathname === '/participants/monthly') {
+    await respond(fetchMonthlyParticipants)
+  } else if (req.method === 'GET' && pathname === '/participants/change-rates') {
+    await respond(fetchParticipantChangeRates)
+  } else if (req.method === 'GET' && pathname === '/participants/scheduled-rewards/daily') {
+    await respond(fetchParticipantScheduledRewards)
+  } else if (req.method === 'GET' && pathname === '/miners/retrieval-success-rate/summary') {
+    await respond(fetchMinersRSRSummary)
   } else if (await handlePlatformRoutes(req, res, pgPools)) {
     // no-op, request was handled by handlePlatformRoute
   } else {

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -53,7 +53,7 @@ const createRespondWithFetchFn = (pathname, searchParams, res, pgPools) => fetch
   )
 }
 
-const sanitizePathname = pathname => `/${pathname.split('/').filter(Boolean).join('/')}`
+export const sanitizePathname = pathname => `/${pathname.split('/').filter(Boolean).join('/')}`
 
 /**
  * @param {import('node:http').IncomingMessage} req

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -53,7 +53,7 @@ const createRespondWithFetchFn = (pathname, searchParams, res, pgPools) => fetch
   )
 }
 
-const sanitizePathname = pathname => pathname.split('/').filter(Boolean).join('/')
+const sanitizePathname = pathname => `/${pathname.split('/').filter(Boolean).join('/')}`
 
 /**
  * @param {import('node:http').IncomingMessage} req

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -43,7 +43,7 @@ const enableCors = (req, res) => {
   }
 }
 
-const respondWithFetchFn = (pathname, searchParams, res, pgPools) => fetchFn => {
+const createRespondWithFetchFn = (pathname, searchParams, res, pgPools) => fetchFn => {
   return getStatsWithFilterAndCaching(
     pathname,
     searchParams,
@@ -63,7 +63,7 @@ const handler = async (req, res, pgPools) => {
   const { pathname, searchParams } = new URL(`http://127.0.0.1${req.url}`)
 
   enableCors(req, res)
-  const respond = respondWithFetchFn(pathname, searchParams, res, pgPools)
+  const respond = createRespondWithFetchFn(pathname, searchParams, res, pgPools)
 
   if (req.method === 'GET' && pathname === '/deals/daily') {
     await respond(fetchDailyDealStats)

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -53,6 +53,8 @@ const createRespondWithFetchFn = (pathname, searchParams, res, pgPools) => fetch
   )
 }
 
+const sanitizePathname = pathname => pathname.split('/').filter(Boolean).join('/')
+
 /**
  * @param {import('node:http').IncomingMessage} req
  * @param {import('node:http').ServerResponse} res
@@ -60,7 +62,8 @@ const createRespondWithFetchFn = (pathname, searchParams, res, pgPools) => fetch
  */
 const handler = async (req, res, pgPools) => {
   // Caveat! `new URL('//foo', 'http://127.0.0.1')` would produce "http://foo/" - not what we want!
-  const { pathname, searchParams } = new URL(`http://127.0.0.1${req.url}`)
+  let { pathname, searchParams } = new URL(`http://127.0.0.1${req.url}`)
+  pathname = sanitizePathname(pathname)
 
   enableCors(req, res)
   const respond = createRespondWithFetchFn(pathname, searchParams, res, pgPools)

--- a/stats/lib/platform-routes.js
+++ b/stats/lib/platform-routes.js
@@ -7,45 +7,32 @@ import {
 } from './platform-stats-fetchers.js'
 import { sanitizePathname } from './handler.js'
 
+const createRespondWithFetchFn = (pathname, searchParams, res) => (pgPool, fetchFn) => {
+  return getStatsWithFilterAndCaching(
+    pathname,
+    searchParams,
+    res,
+    pgPool,
+    fetchFn
+  )
+}
+
 export const handlePlatformRoutes = async (req, res, pgPools) => {
   // Caveat! `new URL('//foo', 'http://127.0.0.1')` would produce "http://foo/" - not what we want!
   let { pathname, searchParams } = new URL(`http://127.0.0.1${req.url}`)
   pathname = sanitizePathname(pathname)
+  const respond = createRespondWithFetchFn(pathname, searchParams, res)
 
-  const routeHandlerInfoMap = {
-    '/stations/daily': {
-      fetchFunction: fetchDailyStationCount,
-      pgPool: pgPools.evaluate
-    },
-    '/stations/monthly': {
-      fetchFunction: fetchMonthlyStationCount,
-      pgPool: pgPools.evaluate
-    },
-    '/measurements/daily': {
-      fetchFunction: fetchDailyStationAcceptedMeasurementCount,
-      pgPool: pgPools.evaluate
-    },
-    '/transfers/daily': {
-      fetchFunction: fetchDailyRewardTransfers,
-      pgPool: pgPools.stats
-    }
+  if (req.method === 'GET' && pathname === '/stations/daily') {
+    await respond(pgPools.evaluate, fetchDailyStationCount)
+  } else if (req.method === 'GET' && pathname === '/stations/monthly') {
+    await respond(pgPools.evaluate, fetchMonthlyStationCount)
+  } else if (req.method === 'GET' && pathname === '/measurements/daily') {
+    await respond(pgPools.evaluate, fetchDailyStationAcceptedMeasurementCount)
+  } else if (req.method === 'GET' && pathname === '/transfers/daily') {
+    await respond(pgPools.stats, fetchDailyRewardTransfers)
+  } else {
+    return false
   }
-
-  const routeHandlerInfo = routeHandlerInfoMap[pathname]
-  if (req.method === 'GET' && routeHandlerInfo) {
-    await getStatsWithFilterAndCaching(
-      pathname,
-      searchParams,
-      res,
-      routeHandlerInfo.pgPool,
-      routeHandlerInfo.fetchFunction
-    )
-    return true
-  } else if (req.method === 'GET' && pathname === '/') {
-    // health check - required by Grafana datasources
-    res.end('OK')
-    return true
-  }
-
-  return false
+  return true
 }

--- a/stats/lib/platform-routes.js
+++ b/stats/lib/platform-routes.js
@@ -5,32 +5,33 @@ import {
   fetchDailyRewardTransfers,
   fetchDailyStationAcceptedMeasurementCount
 } from './platform-stats-fetchers.js'
+import { sanitizePathname } from './handler.js'
 
 export const handlePlatformRoutes = async (req, res, pgPools) => {
   // Caveat! `new URL('//foo', 'http://127.0.0.1')` would produce "http://foo/" - not what we want!
-  const { pathname, searchParams } = new URL(`http://127.0.0.1${req.url}`)
-  const segs = pathname.split('/').filter(Boolean)
+  let { pathname, searchParams } = new URL(`http://127.0.0.1${req.url}`)
+  pathname = sanitizePathname(pathname)
 
   const routeHandlerInfoMap = {
-    'stations/daily': {
+    '/stations/daily': {
       fetchFunction: fetchDailyStationCount,
       pgPool: pgPools.evaluate
     },
-    'stations/monthly': {
+    '/stations/monthly': {
       fetchFunction: fetchMonthlyStationCount,
       pgPool: pgPools.evaluate
     },
-    'measurements/daily': {
+    '/measurements/daily': {
       fetchFunction: fetchDailyStationAcceptedMeasurementCount,
       pgPool: pgPools.evaluate
     },
-    'transfers/daily': {
+    '/transfers/daily': {
       fetchFunction: fetchDailyRewardTransfers,
       pgPool: pgPools.stats
     }
   }
 
-  const routeHandlerInfo = routeHandlerInfoMap[segs.join('/')]
+  const routeHandlerInfo = routeHandlerInfoMap[pathname]
   if (req.method === 'GET' && routeHandlerInfo) {
     await getStatsWithFilterAndCaching(
       pathname,
@@ -40,7 +41,7 @@ export const handlePlatformRoutes = async (req, res, pgPools) => {
       routeHandlerInfo.fetchFunction
     )
     return true
-  } else if (req.method === 'GET' && segs.length === 0) {
+  } else if (req.method === 'GET' && pathname === '/') {
     // health check - required by Grafana datasources
     res.end('OK')
     return true


### PR DESCRIPTION
In preparation for https://github.com/filecoin-station/spark-stats/pull/147#discussion_r1638158012, this makes the path handling more flexible (each route can use its own parsing logic, path segments can be parametrized) while keeping it short using the utility functions