### PR TITLE
feat: `GET /deals/summary`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ Base URL: http://stats.filspark.com/
 
   http://stats.filspark.com/deals/daily
 
+- `GET /deals/summary?from=2024-01-01&to=2024-01-31`
+
+  http://stats.filspark.com/deals/summary
+
+
 ## Development
 
 ### Database

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -10,7 +10,8 @@ import {
   fetchParticipantChangeRates,
   fetchParticipantScheduledRewards,
   fetchParticipantRewardTransfers,
-  fetchRetrievalSuccessRate
+  fetchRetrievalSuccessRate,
+  fetchDealSummary
 } from './stats-fetchers.js'
 
 import { handlePlatformRoutes } from './platform-routes.js'
@@ -83,6 +84,8 @@ const handler = async (req, res, pgPools) => {
 
   if (req.method === 'GET' && url === '/deals/daily') {
     await respond(fetchDailyDealStats)
+  } else if (req.method === 'GET' && url === '/deals/summary') {
+    await respond(fetchDealSummary)
   } else if (req.method === 'GET' && url === '/retrieval-success-rate') {
     await respond(fetchRetrievalSuccessRate)
   } else if (req.method === 'GET' && url === '/participants/daily') {

--- a/stats/lib/stats-fetchers.js
+++ b/stats/lib/stats-fetchers.js
@@ -1,5 +1,4 @@
 import { getDailyDistinctCount, getMonthlyDistinctCount } from './request-helpers.js'
-import assert from 'http-assert'
 
 /** @typedef {import('@filecoin-station/spark-stats-db').PgPools} PgPools */
 /**

--- a/stats/lib/stats-fetchers.js
+++ b/stats/lib/stats-fetchers.js
@@ -1,4 +1,5 @@
 import { getDailyDistinctCount, getMonthlyDistinctCount } from './request-helpers.js'
+import assert from 'http-assert'
 
 /** @typedef {import('@filecoin-station/spark-stats-db').PgPools} PgPools */
 /**
@@ -51,36 +52,7 @@ export const fetchDailyDealStats = async (pgPools, filter) => {
  * @param {import('./typings.js').DateRangeFilter} filter
  */
 export const fetchDealSummary = async (pgPools, filter) => {
-  const { rows: lastDayRows } = await pgPools.evaluate.query(`
-    SELECT
-      SUM(total) as total,
-      SUM(indexed) as indexed,
-      SUM(retrievable) as retrievable
-    FROM daily_deals
-    WHERE day = date_trunc('day', $1::DATE)
-  `, [filter.to])
-
-  const { rows: lastSevenDaysRows } = await pgPools.evaluate.query(`
-    SELECT
-      SUM(total) as total,
-      SUM(indexed) as indexed,
-      SUM(retrievable) as retrievable
-    FROM daily_deals
-    WHERE day > date_trunc('day', $1::DATE) - INTERVAL '7 day'
-      AND day <= date_trunc('day', $1)
-  `, [filter.to])
-
-  const { rows: lastThirtyDaysRows } = await pgPools.evaluate.query(`
-    SELECT
-      SUM(total) as total,
-      SUM(indexed) as indexed,
-      SUM(retrievable) as retrievable
-    FROM daily_deals
-    WHERE day > date_trunc('day', $1::DATE) - INTERVAL '30 day'
-      AND day <= date_trunc('day', $1)
-  `, [filter.to])
-
-  const { rows: requestedIntervalRows } = await pgPools.evaluate.query(`
+  const { rows: [summary] } = await pgPools.evaluate.query(`
     SELECT
       SUM(total) as total,
       SUM(indexed) as indexed,
@@ -88,14 +60,9 @@ export const fetchDealSummary = async (pgPools, filter) => {
     FROM daily_deals
     WHERE day >= date_trunc('day', $1::DATE)
       AND day <= date_trunc('day', $2::DATE)
-  `, [filter.from, filter.to])
-
-  return {
-    requestedInterval: requestedIntervalRows[0],
-    lastDay: lastDayRows[0],
-    lastSevenDays: lastSevenDaysRows[0],
-    lastThirtyDays: lastThirtyDaysRows[0]
-  }
+  `, [filter.from, filter.to]
+  )
+  return summary
 }
 
 export const fetchDailyParticipants = async (pgPools, filter) => {


### PR DESCRIPTION
Return a summary of deals for the selected interval. These values are a bit difficult to calculate on the Grafana side, but I find it easier to build them on our backend.

```js
{
  total: '6900',
  indexed: '709',
  retrievable: '69'
}
```

Links:
- https://github.com/space-meridian/roadmap/issues/57

Screenshot from our internal dashboard to illustrate what I am trying to achieve:

<img width="305" alt="Screenshot 2024-06-21 at 17 54 49" src="https://github.com/filecoin-station/spark-stats/assets/1140553/28126470-bfc9-4fd9-b3e5-7a21255262ee">
