### PR TITLE
Add `total_measurement_count` to `GET /measurements/daily`

### DIFF
--- a/stats/lib/platform-routes.js
+++ b/stats/lib/platform-routes.js
@@ -5,7 +5,7 @@ import {
   fetchDailyRewardTransfers,
   fetchTopEarningParticipants,
   fetchParticipantsWithTopMeasurements,
-  fetchDailyStationAcceptedMeasurementCount
+  fetchDailyStationMeasurementCounts
 } from './platform-stats-fetchers.js'
 
 const createRespondWithFetchFn = (pathname, searchParams, res) => (pgPool, fetchFn) => {
@@ -31,7 +31,7 @@ export const handlePlatformRoutes = async (req, res, pgPools) => {
   } else if (req.method === 'GET' && url === '/stations/monthly') {
     await respond(pgPools.evaluate, fetchMonthlyStationCount)
   } else if (req.method === 'GET' && url === '/measurements/daily') {
-    await respond(pgPools.evaluate, fetchDailyStationAcceptedMeasurementCount)
+    await respond(pgPools.evaluate, fetchDailyStationMeasurementCounts)
   } else if (req.method === 'GET' && url === '/participants/top-measurements') {
     await respond(pgPools.evaluate, fetchParticipantsWithTopMeasurements)
   } else if (req.method === 'GET' && url === '/participants/top-earning') {

--- a/stats/lib/platform-stats-fetchers.js
+++ b/stats/lib/platform-stats-fetchers.js
@@ -38,9 +38,11 @@ export const fetchMonthlyStationCount = async (pgPool, filter) => {
  * @param {Queryable} pgPool
  * @param {import('./typings.js').DateRangeFilter} filter
  */
-export const fetchDailyStationAcceptedMeasurementCount = async (pgPool, filter) => {
+export const fetchDailyStationMeasurementCounts = async (pgPool, filter) => {
   const { rows } = await pgPool.query(`
-    SELECT day::TEXT, SUM(accepted_measurement_count) as accepted_measurement_count
+    SELECT day::TEXT,
+      SUM(accepted_measurement_count) as accepted_measurement_count,
+      SUM(total_measurement_count) as total_measurement_count
     FROM daily_stations
     WHERE day >= $1 AND day <= $2
     GROUP BY day

--- a/stats/test/platform-routes.test.js
+++ b/stats/test/platform-routes.test.js
@@ -54,17 +54,17 @@ describe('Platform Routes HTTP request handler', () => {
   describe('GET /stations/daily', () => {
     it('returns daily station metrics for the given date range', async () => {
       await givenDailyStationMetrics(pgPools.evaluate, '2024-01-10', [
-        { ...STATION_STATS, acceptedMeasurementCount: 1 }
+        { ...STATION_STATS, acceptedMeasurementCount: 1, totalMeasurementCount: 1 }
       ])
       await givenDailyStationMetrics(pgPools.evaluate, '2024-01-11', [
-        { ...STATION_STATS, stationId: 'station2', acceptedMeasurementCount: 1 }
+        { ...STATION_STATS, stationId: 'station2', acceptedMeasurementCount: 1, totalMeasurementCount: 1 }
       ])
       await givenDailyStationMetrics(pgPools.evaluate, '2024-01-12', [
-        { ...STATION_STATS, stationId: 'station2', acceptedMeasurementCount: 2 },
-        { ...STATION_STATS, stationId: 'station3', acceptedMeasurementCount: 1 }
+        { ...STATION_STATS, stationId: 'station2', acceptedMeasurementCount: 2, totalMeasurementCount: 2 },
+        { ...STATION_STATS, stationId: 'station3', acceptedMeasurementCount: 1, totalMeasurementCount: 1 }
       ])
       await givenDailyStationMetrics(pgPools.evaluate, '2024-01-13', [
-        { ...STATION_STATS, acceptedMeasurementCount: 1 }
+        { ...STATION_STATS, acceptedMeasurementCount: 1, totalMeasurementCount: 1 }
       ])
 
       const res = await fetch(
@@ -88,25 +88,25 @@ describe('Platform Routes HTTP request handler', () => {
     it('returns monthly station metrics for the given date range ignoring the day number', async () => {
       // before the date range
       await givenDailyStationMetrics(pgPools.evaluate, '2023-12-31', [
-        { ...STATION_STATS, acceptedMeasurementCount: 1 }
+        { ...STATION_STATS, acceptedMeasurementCount: 1, totalMeasurementCount: 1 }
       ])
       // in the date range
       await givenDailyStationMetrics(pgPools.evaluate, '2024-01-10', [
-        { ...STATION_STATS, acceptedMeasurementCount: 1 }
+        { ...STATION_STATS, acceptedMeasurementCount: 1, totalMeasurementCount: 1 }
       ])
       await givenDailyStationMetrics(pgPools.evaluate, '2024-01-11', [
-        { ...STATION_STATS, stationId: 'station2', acceptedMeasurementCount: 1 }
+        { ...STATION_STATS, stationId: 'station2', acceptedMeasurementCount: 1, totalMeasurementCount: 1 }
       ])
       await givenDailyStationMetrics(pgPools.evaluate, '2024-01-12', [
-        { ...STATION_STATS, stationId: 'station2', acceptedMeasurementCount: 2 },
-        { ...STATION_STATS, stationId: 'station3', acceptedMeasurementCount: 1 }
+        { ...STATION_STATS, stationId: 'station2', acceptedMeasurementCount: 2, totalMeasurementCount: 2 },
+        { ...STATION_STATS, stationId: 'station3', acceptedMeasurementCount: 1, totalMeasurementCount: 1 }
       ])
       await givenDailyStationMetrics(pgPools.evaluate, '2024-02-13', [
-        { ...STATION_STATS, acceptedMeasurementCount: 1 }
+        { ...STATION_STATS, acceptedMeasurementCount: 1, totalMeasurementCount: 1 }
       ])
       // after the date range
       await givenDailyStationMetrics(pgPools.evaluate, '2024-03-01', [
-        { ...STATION_STATS, acceptedMeasurementCount: 1 }
+        { ...STATION_STATS, acceptedMeasurementCount: 1, totalMeasurementCount: 1 }
       ])
 
       const res = await fetch(
@@ -162,13 +162,13 @@ describe('Platform Routes HTTP request handler', () => {
   describe('GET /participants/top-measurements', () => {
     it('returns top measurement stations for the given date', async () => {
       await givenDailyStationMetrics(pgPools.evaluate, yesterday(), [
-        { ...STATION_STATS, stationId: 's3', participantAddress: 'f1ghijkl', acceptedMeasurementCount: 50 },
-        { ...STATION_STATS, acceptedMeasurementCount: 20 },
-        { ...STATION_STATS, stationId: 's2', acceptedMeasurementCount: 30 },
-        { ...STATION_STATS, stationId: 's2', inetGroup: 'group2', acceptedMeasurementCount: 40 }
+        { ...STATION_STATS, stationId: 's3', participantAddress: 'f1ghijkl', acceptedMeasurementCount: 50, totalMeasurementCount: 50 },
+        { ...STATION_STATS, acceptedMeasurementCount: 20, totalMeasurementCount: 20 },
+        { ...STATION_STATS, stationId: 's2', acceptedMeasurementCount: 30, totalMeasurementCount: 30 },
+        { ...STATION_STATS, stationId: 's2', inetGroup: 'group2', acceptedMeasurementCount: 40, totalMeasurementCount: 40 }
       ])
       await givenDailyStationMetrics(pgPools.evaluate, today(), [
-        { ...STATION_STATS, acceptedMeasurementCount: 10 }
+        { ...STATION_STATS, acceptedMeasurementCount: 10, totalMeasurementCount: 10 }
       ])
 
       await pgPools.evaluate.query('REFRESH MATERIALIZED VIEW top_measurement_participants_yesterday_mv')


### PR DESCRIPTION
For https://github.com/filecoin-station/site-backend/pull/14

Instead of making a breaking change, it's easier and more useful to expose `total_measurement_count` in addition to `accepted_measurement_count`.