### PR TITLE
feat: API for deals tracked per miner/client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,5 +31,3 @@ updates:
       interval: "daily"
       time: "15:00"
       timezone: "Europe/Berlin"
-
-r

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,5 @@ updates:
       interval: "daily"
       time: "15:00"
       timezone: "Europe/Berlin"
+
+r

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
     env:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/spark_stats
       EVALUATE_DB_URL: postgres://postgres:postgres@localhost:5432/spark_evaluate
+      API_DB_URL: postgres://postgres:postgres@localhost:5432/spark
       NPM_CONFIG_WORKSPACE: stats
     steps:
       - run: psql "${DATABASE_URL}" -c "CREATE DATABASE spark_evaluate"
@@ -55,6 +56,7 @@ jobs:
     env:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/spark_stats
       EVALUATE_DB_URL: postgres://postgres:postgres@localhost:5432/spark_evaluate
+      API_DB_URL: postgres://postgres:postgres@localhost:5432/spark
       NPM_CONFIG_WORKSPACE: observer
     steps:
       - run: psql "${DATABASE_URL}" -c "CREATE DATABASE spark_evaluate"
@@ -96,6 +98,7 @@ jobs:
     env:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/spark_stats
       EVALUATE_DB_URL: postgres://postgres:postgres@localhost:5432/spark_evaluate
+      API_DB_URL: postgres://postgres:postgres@localhost:5432/spark
       NPM_CONFIG_WORKSPACE: observer
     steps:
       - run: psql "${DATABASE_URL}" -c "CREATE DATABASE spark_evaluate"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       NPM_CONFIG_WORKSPACE: stats
     steps:
       - run: psql "${DATABASE_URL}" -c "CREATE DATABASE spark_evaluate"
+      - run: psql "${DATABASE_URL}" -c "CREATE DATABASE spark"
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -60,6 +61,7 @@ jobs:
       NPM_CONFIG_WORKSPACE: observer
     steps:
       - run: psql "${DATABASE_URL}" -c "CREATE DATABASE spark_evaluate"
+      - run: psql "${DATABASE_URL}" -c "CREATE DATABASE spark"
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -102,6 +104,7 @@ jobs:
       NPM_CONFIG_WORKSPACE: observer
     steps:
       - run: psql "${DATABASE_URL}" -c "CREATE DATABASE spark_evaluate"
+      - run: psql "${DATABASE_URL}" -c "CREATE DATABASE spark"
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Base URL: http://stats.filspark.com/
 
   http://stats.filspark.com/miners/retrieval-success-rate/summary
 
+- `GET /miner/:id/tracked-deals/summary`
+
+  http://stats.filspark.com/miner/f0814049/tracked-deals/summary
+
+- `GET /client/:id/tracked-deals/summary`
+
+  http://stats.filspark.com/client/f0215074/tracked-deals/summary
+
 - `GET /participants/daily?from=<day>&to=<day>`
 
   http://stats.filspark.com/participants/daily
@@ -48,9 +56,6 @@ Base URL: http://stats.filspark.com/
 
   http://stats.filspark.com/participant//0x000000000000000000000000000000000000dEaD/reward-transfers
 
-- `GET /miners/retrieval-success-rate/summary?from=<day>&to=<day>`
-
-  http://stats.filspark.com/miners/retrieval-success-rate/summary
 
 - `GET /stations/daily?from=<day>&to=<day>`
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Base URL: http://stats.filspark.com/
 
   http://stats.filspark.com/miners/retrieval-success-rate/summary
 
-- `GET /miner/:id/tracked-deals/summary`
+- `GET /miner/:id/deals/eligible/summary`
 
-  http://stats.filspark.com/miner/f0814049/tracked-deals/summary
+  http://stats.filspark.com/miner/f0814049/deals/eligible/summary
 
-- `GET /client/:id/tracked-deals/summary`
+- `GET /client/:id/deals/eligible/summary`
 
-  http://stats.filspark.com/client/f0215074/tracked-deals/summary
+  http://stats.filspark.com/client/f0215074/deals/eligible/summary
 
 - `GET /participants/daily?from=<day>&to=<day>`
 

--- a/db/package.json
+++ b/db/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "pg": "^8.12.0",
     "postgrator": "^7.2.0",
+    "spark-api": "filecoin-station/spark-api#main",
     "spark-evaluate": "filecoin-station/spark-evaluate#main"
   },
   "standard": {

--- a/db/package.json
+++ b/db/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "pg": "^8.12.0",
     "postgrator": "^7.2.0",
-    "spark-api": "filecoin-station/spark-api#main",
+    "spark-api": "https://github.com/filecoin-station/spark-api/archive/refs/heads/main.tar.gz",
     "spark-evaluate": "filecoin-station/spark-evaluate#main"
   },
   "standard": {

--- a/db/package.json
+++ b/db/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "pg": "^8.12.0",
     "postgrator": "^7.2.0",
-    "spark-api": "https://github.com/filecoin-station/spark-api/archive/refs/heads/main.tar.gz",
+    "spark-api": "https://github.com/filecoin-station/spark-api/archive/3de5c3325ef6cc40df02769b96957d33279d38c1.tar.gz",
     "spark-evaluate": "filecoin-station/spark-evaluate#main"
   },
   "standard": {

--- a/db/typings.d.ts
+++ b/db/typings.d.ts
@@ -8,13 +8,19 @@ export interface PgPoolStats extends pg.Pool {
   db: 'stats'
 }
 
+export interface PgPoolApi extends pg.Pool {
+  db: 'api'
+}
+
 export type PgPool =
  | PgPoolEvaluate
  | PgPoolStats
+ | PgPoolApi
 
 export interface PgPools {
   stats: PgPoolStats;
   evaluate: PgPoolEvaluate;
+  api: PgPoolApi;
   end(): Promise<void>
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "dependencies": {
         "pg": "^8.12.0",
         "postgrator": "^7.2.0",
+        "spark-api": "filecoin-station/spark-api#main",
         "spark-evaluate": "filecoin-station/spark-evaluate#main"
       },
       "devDependencies": {
@@ -4821,6 +4822,15 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/spark-api": {
+      "name": "@filecoin-station/spark-api-monorepo",
+      "resolved": "git+ssh://git@github.com/filecoin-station/spark-api.git#74df75770c28a15ff8d12966abdc7f4dd13e9a5f",
+      "license": "MIT",
+      "workspaces": [
+        "api",
+        "publish"
+      ]
     },
     "node_modules/sparse-array": {
       "version": "1.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       "dependencies": {
         "pg": "^8.12.0",
         "postgrator": "^7.2.0",
-        "spark-api": "filecoin-station/spark-api#main",
+        "spark-api": "https://github.com/filecoin-station/spark-api/archive/refs/heads/main.tar.gz",
         "spark-evaluate": "filecoin-station/spark-evaluate#main"
       },
       "devDependencies": {
@@ -4825,7 +4825,8 @@
     },
     "node_modules/spark-api": {
       "name": "@filecoin-station/spark-api-monorepo",
-      "resolved": "git+ssh://git@github.com/filecoin-station/spark-api.git#74df75770c28a15ff8d12966abdc7f4dd13e9a5f",
+      "resolved": "https://github.com/filecoin-station/spark-api/archive/refs/heads/main.tar.gz",
+      "integrity": "sha512-D8GTx9UWQuntKBqByxFT6i43VxXx6a9KfH4O2WIXTiN/NhN1QGX7MuVekg0BTLHcOYv+gpyJzFK/7KhRDcObxg==",
       "license": "MIT",
       "workspaces": [
         "api",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,12 +23,22 @@
       "dependencies": {
         "pg": "^8.12.0",
         "postgrator": "^7.2.0",
-        "spark-api": "https://github.com/filecoin-station/spark-api/archive/refs/heads/main.tar.gz",
+        "spark-api": "https://github.com/filecoin-station/spark-api/archive/3de5c3325ef6cc40df02769b96957d33279d38c1.tar.gz",
         "spark-evaluate": "filecoin-station/spark-evaluate#main"
       },
       "devDependencies": {
         "standard": "^17.1.0"
       }
+    },
+    "db/node_modules/spark-api": {
+      "name": "@filecoin-station/spark-api-monorepo",
+      "resolved": "https://github.com/filecoin-station/spark-api/archive/3de5c3325ef6cc40df02769b96957d33279d38c1.tar.gz",
+      "integrity": "sha512-7YVSZv6JZOQfTrMxwuRjXXLuTzeHlejGLSKGi/nFeQGivMcfC9Ds9jSA9XhRZj+9oF+k5fZS4Y/uT3/3OnUUJg==",
+      "license": "MIT",
+      "workspaces": [
+        "api",
+        "publish"
+      ]
     },
     "db/node_modules/spark-evaluate": {
       "resolved": "git+ssh://git@github.com/filecoin-station/spark-evaluate.git#24c5e1bcf083a40ab4a0968d427e465ace48a724",
@@ -4822,16 +4832,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/spark-api": {
-      "name": "@filecoin-station/spark-api-monorepo",
-      "resolved": "https://github.com/filecoin-station/spark-api/archive/refs/heads/main.tar.gz",
-      "integrity": "sha512-D8GTx9UWQuntKBqByxFT6i43VxXx6a9KfH4O2WIXTiN/NhN1QGX7MuVekg0BTLHcOYv+gpyJzFK/7KhRDcObxg==",
-      "license": "MIT",
-      "workspaces": [
-        "api",
-        "publish"
-      ]
     },
     "node_modules/sparse-array": {
       "version": "1.3.2",

--- a/stats/bin/migrate.js
+++ b/stats/bin/migrate.js
@@ -1,5 +1,11 @@
-import { migrateStatsDB, migrateEvaluateDB, getPgPools } from '@filecoin-station/spark-stats-db'
+import {
+  getPgPools,
+  migrateApiDB,
+  migrateEvaluateDB,
+  migrateStatsDB
+} from '@filecoin-station/spark-stats-db'
 
 const pgPools = await getPgPools()
 await migrateStatsDB(pgPools.stats)
 await migrateEvaluateDB(pgPools.evaluate)
+await migrateApiDB(pgPools.api)

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -101,9 +101,9 @@ const handler = async (req, res, pgPools) => {
     await respond(fetchParticipantRewardTransfers, segs[1])
   } else if (req.method === 'GET' && url === '/miners/retrieval-success-rate/summary') {
     await respond(fetchMinersRSRSummary)
-  } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'tracked-deals' && segs[3] === 'summary') {
+  } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'deals' && segs[3] === 'eligible' && segs[4] === 'summary') {
     await getRetrievableDealsForMiner(req, res, pgPools.api, segs[1])
-  } else if (req.method === 'GET' && segs[0] === 'client' && segs[1] && segs[2] === 'tracked-deals' && segs[3] === 'summary') {
+  } else if (req.method === 'GET' && segs[0] === 'client' && segs[1] && segs[2] === 'deals' && segs[3] === 'eligible' && segs[4] === 'summary') {
     await getRetrievableDealsForClient(req, res, pgPools.api, segs[1])
   } else if (await handlePlatformRoutes(req, res, pgPools)) {
     // no-op, request was handled by handlePlatformRoute

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/node'
+import { json } from 'http-responders'
 
 import { getStatsWithFilterAndCaching } from './request-helpers.js'
 
@@ -100,6 +101,10 @@ const handler = async (req, res, pgPools) => {
     await respond(fetchParticipantRewardTransfers, segs[1])
   } else if (req.method === 'GET' && url === '/miners/retrieval-success-rate/summary') {
     await respond(fetchMinersRSRSummary)
+  } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'tracked-deals' && segs[3] === 'summary') {
+    await getRetrievableDealsForMiner(req, res, pgPools.api, segs[1])
+  } else if (req.method === 'GET' && segs[0] === 'client' && segs[1] && segs[2] === 'tracked-deals' && segs[3] === 'summary') {
+    await getRetrievableDealsForClient(req, res, pgPools.api, segs[1])
   } else if (await handlePlatformRoutes(req, res, pgPools)) {
     // no-op, request was handled by handlePlatformRoute
   } else if (req.method === 'GET' && url === '/') {
@@ -131,4 +136,62 @@ const errorHandler = (res, err, logger) => {
 const notFound = (res) => {
   res.statusCode = 404
   res.end('Not Found')
+}
+
+/**
+ * @param {import('node:http').IncomingMessage} _req
+ * @param {import('node:http').ServerResponse} res
+ * @param {PgPools['api']} client
+ * @param {string} minerId
+ */
+const getRetrievableDealsForMiner = async (_req, res, client, minerId) => {
+  /** @type {{rows: {client_id: string; deal_count: number}[]}} */
+  const { rows } = await client.query(`
+    SELECT client_id, COUNT(cid)::INTEGER as deal_count FROM retrievable_deals
+    WHERE miner_id = $1 AND expires_at > now()
+    GROUP BY client_id
+    ORDER BY deal_count DESC, client_id ASC
+    `, [
+    minerId
+  ])
+
+  // Cache the response for 6 hours
+  res.setHeader('cache-control', `max-age=${6 * 3600}`)
+
+  const body = {
+    minerId,
+    dealCount: rows.reduce((sum, row) => sum + row.deal_count, 0),
+    clients:
+      rows.map(
+        // eslint-disable-next-line camelcase
+        ({ client_id, deal_count }) => ({ clientId: client_id, dealCount: deal_count })
+      )
+  }
+
+  json(res, body)
+}
+
+const getRetrievableDealsForClient = async (_req, res, client, clientId) => {
+  /** @type {{rows: {miner_id: string; deal_count: number}[]}} */
+  const { rows } = await client.query(`
+    SELECT miner_id, COUNT(cid)::INTEGER as deal_count FROM retrievable_deals
+    WHERE client_id = $1 AND expires_at > now()
+    GROUP BY miner_id
+    ORDER BY deal_count DESC, miner_id ASC
+    `, [
+    clientId
+  ])
+
+  // Cache the response for 6 hours
+  res.setHeader('cache-control', `max-age=${6 * 3600}`)
+
+  const body = {
+    clientId,
+    dealCount: rows.reduce((sum, row) => sum + row.deal_count, 0),
+    providers: rows.map(
+      // eslint-disable-next-line camelcase
+      ({ miner_id, deal_count }) => ({ minerId: miner_id, dealCount: deal_count })
+    )
+  }
+  json(res, body)
 }

--- a/stats/test/handler.test.js
+++ b/stats/test/handler.test.js
@@ -433,7 +433,7 @@ describe('HTTP request handler', () => {
     })
   })
 
-  describe('tracked-deals summary', () => {
+  describe('summary of eligible deals', () => {
     before(async () => {
       await pgPools.api.query(`
         INSERT INTO retrievable_deals (cid, miner_id, client_id, expires_at)
@@ -450,9 +450,9 @@ describe('HTTP request handler', () => {
       `)
     })
 
-    describe('GET /miner/{id}/tracked-deals/summary', () => {
+    describe('GET /miner/{id}/deals/eligible/summary', () => {
       it('returns deal counts grouped by client id', async () => {
-        const res = await fetch(new URL('/miner/f0230/tracked-deals/summary', baseUrl))
+        const res = await fetch(new URL('/miner/f0230/deals/eligible/summary', baseUrl))
         await assertResponseStatus(res, 200)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
         const body = await res.json()
@@ -468,7 +468,7 @@ describe('HTTP request handler', () => {
       })
 
       it('returns an empty array for miners with no deals in our DB', async () => {
-        const res = await fetch(new URL('/miner/f0000/tracked-deals/summary', baseUrl))
+        const res = await fetch(new URL('/miner/f0000/deals/eligible/summary', baseUrl))
         await assertResponseStatus(res, 200)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
         const body = await res.json()
@@ -480,9 +480,9 @@ describe('HTTP request handler', () => {
       })
     })
 
-    describe('GET /client/{id}/tracked-deals/summary', () => {
+    describe('GET /client/{id}/deals/eligible/summary', () => {
       it('returns deal counts grouped by miner id', async () => {
-        const res = await fetch(new URL('/client/f0800/tracked-deals/summary', baseUrl))
+        const res = await fetch(new URL('/client/f0800/deals/eligible/summary', baseUrl))
         await assertResponseStatus(res, 200)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
         const body = await res.json()
@@ -498,7 +498,7 @@ describe('HTTP request handler', () => {
       })
 
       it('returns an empty array for miners with no deals in our DB', async () => {
-        const res = await fetch(new URL('/client/f0000/tracked-deals/summary', baseUrl))
+        const res = await fetch(new URL('/client/f0000/deals/eligible/summary', baseUrl))
         await assertResponseStatus(res, 200)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
         const body = await res.json()

--- a/stats/test/handler.test.js
+++ b/stats/test/handler.test.js
@@ -433,6 +433,84 @@ describe('HTTP request handler', () => {
     })
   })
 
+  describe('tracked-deals summary', () => {
+    before(async () => {
+      await pgPools.api.query(`
+        INSERT INTO retrievable_deals (cid, miner_id, client_id, expires_at)
+        VALUES
+        ('bafyone', 'f0210', 'f0800', '2100-01-01'),
+        ('bafyone', 'f0220', 'f0800', '2100-01-01'),
+        ('bafytwo', 'f0220', 'f0810', '2100-01-01'),
+        ('bafyone', 'f0230', 'f0800', '2100-01-01'),
+        ('bafytwo', 'f0230', 'f0800', '2100-01-01'),
+        ('bafythree', 'f0230', 'f0810', '2100-01-01'),
+        ('bafyfour', 'f0230', 'f0820', '2100-01-01'),
+        ('bafyexpired', 'f0230', 'f0800', '2020-01-01')
+        ON CONFLICT DO NOTHING
+      `)
+    })
+
+    describe('GET /miner/{id}/tracked-deals/summary', () => {
+      it('returns deal counts grouped by client id', async () => {
+        const res = await fetch(new URL('/miner/f0230/tracked-deals/summary', baseUrl))
+        await assertResponseStatus(res, 200)
+        assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
+        const body = await res.json()
+        assert.deepStrictEqual(body, {
+          minerId: 'f0230',
+          dealCount: 4,
+          clients: [
+            { clientId: 'f0800', dealCount: 2 },
+            { clientId: 'f0810', dealCount: 1 },
+            { clientId: 'f0820', dealCount: 1 }
+          ]
+        })
+      })
+
+      it('returns an empty array for miners with no deals in our DB', async () => {
+        const res = await fetch(new URL('/miner/f0000/tracked-deals/summary', baseUrl))
+        await assertResponseStatus(res, 200)
+        assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
+        const body = await res.json()
+        assert.deepStrictEqual(body, {
+          minerId: 'f0000',
+          dealCount: 0,
+          clients: []
+        })
+      })
+    })
+
+    describe('GET /client/{id}/tracked-deals/summary', () => {
+      it('returns deal counts grouped by miner id', async () => {
+        const res = await fetch(new URL('/client/f0800/tracked-deals/summary', baseUrl))
+        await assertResponseStatus(res, 200)
+        assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
+        const body = await res.json()
+        assert.deepStrictEqual(body, {
+          clientId: 'f0800',
+          dealCount: 4,
+          providers: [
+            { minerId: 'f0230', dealCount: 2 },
+            { minerId: 'f0210', dealCount: 1 },
+            { minerId: 'f0220', dealCount: 1 }
+          ]
+        })
+      })
+
+      it('returns an empty array for miners with no deals in our DB', async () => {
+        const res = await fetch(new URL('/client/f0000/tracked-deals/summary', baseUrl))
+        await assertResponseStatus(res, 200)
+        assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
+        const body = await res.json()
+        assert.deepStrictEqual(body, {
+          clientId: 'f0000',
+          dealCount: 0,
+          providers: []
+        })
+      })
+    })
+  })
+
   describe('GET /deals/daily', () => {
     it('returns daily deal stats for the given date range', async () => {
       await givenDailyDealStats(pgPools.evaluate, { day: '2024-01-10', total: 10, indexed: 5, retrievable: 1 })


### PR DESCRIPTION
Links:
- https://github.com/filecoin-station/spark-api/pull/388.
- https://github.com/filecoin-station/spark-api/pull/386
- https://github.com/filecoin-station/spark/issues/78

Out of the scope of this pull request:

- querying deals by allocator id

Example request:

```
GET /miner/f0814049/deals/eligible/summary
```

Example response:

```json
{
  "minerId": "f0814049",
  "dealCount": 10006,
  "clients": [
    { "clientId": "f02516933", "dealCount": 6880 },
    { "clientId": "f02833886", "dealCount": 3126 }
  ]
}
```

Example request:

```
GET /clients/f0215074/deals/eligible/summary
```

Example response:

```json
{
  "clientId": "f0215074",
  "dealCount": 5350,
  "providers": [
    { "minerId": "f0406478", "dealCount": 4592 },
    { "minerId": "f0814049", "dealCount": 758 }
  ]
}
```
