### PR TITLE
feat: API for deals tracked per allocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Base URL: http://stats.filspark.com/
 
   http://stats.filspark.com/client/f0215074/deals/eligible/summary
 
+- `GET /allocator/:id/deals/eligible/summary`
+
+  http://stats.filspark.com/allocator/f03015751/deals/eligible/summary
+
 - `GET /participants/daily?from=<day>&to=<day>`
 
   http://stats.filspark.com/participants/daily

--- a/db/package.json
+++ b/db/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "pg": "^8.12.0",
     "postgrator": "^7.2.0",
-    "spark-api": "https://github.com/filecoin-station/spark-api/archive/3de5c3325ef6cc40df02769b96957d33279d38c1.tar.gz",
+    "spark-api": "https://github.com/filecoin-station/spark-api/archive/7075fb55b253d48d5d5eb4846f13a3f688d80437.tar.gz",
     "spark-evaluate": "filecoin-station/spark-evaluate#main"
   },
   "standard": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       "dependencies": {
         "pg": "^8.12.0",
         "postgrator": "^7.2.0",
-        "spark-api": "https://github.com/filecoin-station/spark-api/archive/3de5c3325ef6cc40df02769b96957d33279d38c1.tar.gz",
+        "spark-api": "https://github.com/filecoin-station/spark-api/archive/7075fb55b253d48d5d5eb4846f13a3f688d80437.tar.gz",
         "spark-evaluate": "filecoin-station/spark-evaluate#main"
       },
       "devDependencies": {
@@ -32,8 +32,7 @@
     },
     "db/node_modules/spark-api": {
       "name": "@filecoin-station/spark-api-monorepo",
-      "resolved": "https://github.com/filecoin-station/spark-api/archive/3de5c3325ef6cc40df02769b96957d33279d38c1.tar.gz",
-      "integrity": "sha512-7YVSZv6JZOQfTrMxwuRjXXLuTzeHlejGLSKGi/nFeQGivMcfC9Ds9jSA9XhRZj+9oF+k5fZS4Y/uT3/3OnUUJg==",
+      "resolved": "https://github.com/filecoin-station/spark-api/archive/7075fb55b253d48d5d5eb4846f13a3f688d80437.tar.gz",
       "license": "MIT",
       "workspaces": [
         "api",

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -105,6 +105,8 @@ const handler = async (req, res, pgPools) => {
     await getRetrievableDealsForMiner(req, res, pgPools.api, segs[1])
   } else if (req.method === 'GET' && segs[0] === 'client' && segs[1] && segs[2] === 'deals' && segs[3] === 'eligible' && segs[4] === 'summary') {
     await getRetrievableDealsForClient(req, res, pgPools.api, segs[1])
+  } else if (req.method === 'GET' && segs[0] === 'allocator' && segs[1] && segs[2] === 'deals' && segs[3] === 'eligible' && segs[4] === 'summary') {
+    await getRetrievableDealsForAllocator(req, res, pgPools.api, segs[1])
   } else if (await handlePlatformRoutes(req, res, pgPools)) {
     // no-op, request was handled by handlePlatformRoute
   } else if (req.method === 'GET' && url === '/') {
@@ -191,6 +193,33 @@ const getRetrievableDealsForClient = async (_req, res, client, clientId) => {
     providers: rows.map(
       // eslint-disable-next-line camelcase
       ({ miner_id, deal_count }) => ({ minerId: miner_id, dealCount: deal_count })
+    )
+  }
+  json(res, body)
+}
+
+const getRetrievableDealsForAllocator = async (_req, res, client, allocatorId) => {
+  /** @type {{rows: {client_id: string; deal_count: number}[]}} */
+  const { rows } = await client.query(`
+    SELECT ac.client_id, COUNT(cid)::INTEGER as deal_count
+    FROM allocator_clients ac
+    LEFT JOIN retrievable_deals rd ON ac.client_id = rd.client_id
+    WHERE ac.allocator_id = $1 AND expires_at > now()
+    GROUP BY ac.client_id
+    ORDER BY deal_count DESC, ac.client_id ASC
+    `, [
+    allocatorId
+  ])
+
+  // Cache the response for 6 hours
+  res.setHeader('cache-control', `max-age=${6 * 3600}`)
+
+  const body = {
+    allocatorId,
+    dealCount: rows.reduce((sum, row) => sum + row.deal_count, 0),
+    clients: rows.map(
+      // eslint-disable-next-line camelcase
+      ({ client_id, deal_count }) => ({ clientId: client_id, dealCount: deal_count })
     )
   }
   json(res, body)

--- a/stats/test/handler.test.js
+++ b/stats/test/handler.test.js
@@ -448,6 +448,15 @@ describe('HTTP request handler', () => {
         ('bafyexpired', 'f0230', 'f0800', '2020-01-01')
         ON CONFLICT DO NOTHING
       `)
+
+      await pgPools.api.query(`
+        INSERT INTO allocator_clients (allocator_id, client_id)
+        VALUES
+        ('f0500', 'f0800'),
+        ('f0500', 'f0810'),
+        ('f0520', 'f0820')
+        ON CONFLICT DO NOTHING
+      `)
     })
 
     describe('GET /miner/{id}/deals/eligible/summary', () => {
@@ -506,6 +515,35 @@ describe('HTTP request handler', () => {
           clientId: 'f0000',
           dealCount: 0,
           providers: []
+        })
+      })
+    })
+
+    describe('GET /allocator/{id}/deals/eligible/summary', () => {
+      it('returns deal counts grouped by client id', async () => {
+        const res = await fetch(new URL('/allocator/f0500/deals/eligible/summary', baseUrl))
+        await assertResponseStatus(res, 200)
+        assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
+        const body = await res.json()
+        assert.deepStrictEqual(body, {
+          allocatorId: 'f0500',
+          dealCount: 6,
+          clients: [
+            { clientId: 'f0800', dealCount: 4 },
+            { clientId: 'f0810', dealCount: 2 }
+          ]
+        })
+      })
+
+      it('returns an empty array for miners with no deals in our DB', async () => {
+        const res = await fetch(new URL('/allocator/f0000/deals/eligible/summary', baseUrl))
+        await assertResponseStatus(res, 200)
+        assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
+        const body = await res.json()
+        assert.deepStrictEqual(body, {
+          allocatorId: 'f0000',
+          dealCount: 0,
+          clients: []
         })
       })
     })


### PR DESCRIPTION
- **deps: upgrade spark-api to latest**
- **feat: API for deals tracked per allocator**

Example request:

```
GET /allocator/f03015751/deals/eligible/summary
```

Example response:

```json
{
  "allocatorId": "f03019831",
  "dealCount": 117596,
  "clients": [
    {
      "clientId": "f02056762",
      "dealCount": 64674
    },
    {
      "clientId": "f03146638",
      "dealCount": 21405
    }
  ]
}
```

Links:
- https://github.com/filecoin-station/spark/issues/78
- https://github.com/filecoin-station/spark-api/pull/393
