### PR TITLE
feat: handle eligible deal stats via spark-api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,9 @@ jobs:
     env:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/spark_stats
       EVALUATE_DB_URL: postgres://postgres:postgres@localhost:5432/spark_evaluate
-      API_DB_URL: postgres://postgres:postgres@localhost:5432/spark
       NPM_CONFIG_WORKSPACE: stats
     steps:
       - run: psql "${DATABASE_URL}" -c "CREATE DATABASE spark_evaluate"
-      - run: psql "${DATABASE_URL}" -c "CREATE DATABASE spark"
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -57,11 +55,9 @@ jobs:
     env:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/spark_stats
       EVALUATE_DB_URL: postgres://postgres:postgres@localhost:5432/spark_evaluate
-      API_DB_URL: postgres://postgres:postgres@localhost:5432/spark
       NPM_CONFIG_WORKSPACE: observer
     steps:
       - run: psql "${DATABASE_URL}" -c "CREATE DATABASE spark_evaluate"
-      - run: psql "${DATABASE_URL}" -c "CREATE DATABASE spark"
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -100,11 +96,9 @@ jobs:
     env:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/spark_stats
       EVALUATE_DB_URL: postgres://postgres:postgres@localhost:5432/spark_evaluate
-      API_DB_URL: postgres://postgres:postgres@localhost:5432/spark
       NPM_CONFIG_WORKSPACE: observer
     steps:
       - run: psql "${DATABASE_URL}" -c "CREATE DATABASE spark_evaluate"
-      - run: psql "${DATABASE_URL}" -c "CREATE DATABASE spark"
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/db/index.js
+++ b/db/index.js
@@ -1,5 +1,4 @@
 import { migrateWithPgClient as migrateEvaluateDB } from 'spark-evaluate/lib/migrate.js'
-import { migrate as migrateApiDB } from 'spark-api/migrations/index.js'
 import pg from 'pg'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -9,17 +8,13 @@ import Postgrator from 'postgrator'
 /** @typedef {import('./typings.js').PgPools} PgPools */
 /** @typedef {import('./typings.js').PgPoolStats} PgPoolStats */
 /** @typedef {import('./typings.js').PgPoolEvaluate} PgPoolEvaluate */
-/** @typedef {import('./typings.js').PgPoolApi} PgPoolApi */
 /** @typedef {import('./typings.js').Queryable} Queryable */
 
-export { migrateEvaluateDB, migrateApiDB }
+export { migrateEvaluateDB }
 
 const {
   // DATABASE_URL points to `spark_stats` database managed by this monorepo
   DATABASE_URL = 'postgres://localhost:5432/spark_stats',
-
-  // API_DB_URL points to `spark` database managed by spark-api repo.
-  API_DB_URL = 'postgres://localhost:5432/spark',
 
   // EVALUATE_DB_URL points to `spark_evaluate` database managed by spark-evaluate repo.
   // Eventually, we should move the code updating stats from spark-evaluate to this repo
@@ -85,31 +80,14 @@ export const getEvaluatePgPool = async () => {
 }
 
 /**
- * @returns {Promise<PgPoolApi>}
- */
-export const getApiPgPool = async () => {
-  const stats = Object.assign(
-    new pg.Pool({
-      ...poolConfig,
-      connectionString: API_DB_URL
-    }),
-    /** @type {const} */({ db: 'api' })
-  )
-  stats.on('error', onError)
-  await stats.query('SELECT 1')
-  return stats
-}
-
-/**
  * @returns {Promise<PgPools>}
  */
 export const getPgPools = async () => {
   const stats = await getStatsPgPool()
   const evaluate = await getEvaluatePgPool()
-  const api = await getApiPgPool()
-  const end = async () => { await Promise.all([stats.end(), evaluate.end(), api.end()]) }
+  const end = async () => { await Promise.all([stats.end(), evaluate.end()]) }
 
-  return { stats, evaluate, api, end }
+  return { stats, evaluate, end }
 }
 
 /**

--- a/db/package.json
+++ b/db/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "pg": "^8.12.0",
     "postgrator": "^7.2.0",
-    "spark-api": "https://github.com/filecoin-station/spark-api/archive/7075fb55b253d48d5d5eb4846f13a3f688d80437.tar.gz",
     "spark-evaluate": "filecoin-station/spark-evaluate#main"
   },
   "standard": {

--- a/db/typings.d.ts
+++ b/db/typings.d.ts
@@ -8,19 +8,13 @@ export interface PgPoolStats extends pg.Pool {
   db: 'stats'
 }
 
-export interface PgPoolApi extends pg.Pool {
-  db: 'api'
-}
-
 export type PgPool =
  | PgPoolEvaluate
  | PgPoolStats
- | PgPoolApi
 
 export interface PgPools {
   stats: PgPoolStats;
   evaluate: PgPoolEvaluate;
-  api: PgPoolApi;
   end(): Promise<void>
 }
 

--- a/observer/test/observer.test.js
+++ b/observer/test/observer.test.js
@@ -128,8 +128,6 @@ describe('observer', () => {
 
   describe('observeScheduledRewards', () => {
     beforeEach(async () => {
-      await pgPools.evaluate.query('DELETE FROM recent_station_details')
-      await pgPools.evaluate.query('DELETE FROM recent_participant_subnets')
       await pgPools.evaluate.query('DELETE FROM daily_participants')
       await pgPools.evaluate.query('DELETE FROM participants')
       await pgPools.stats.query('DELETE FROM daily_scheduled_rewards')

--- a/observer/test/observer.test.js
+++ b/observer/test/observer.test.js
@@ -128,6 +128,8 @@ describe('observer', () => {
 
   describe('observeScheduledRewards', () => {
     beforeEach(async () => {
+      await pgPools.evaluate.query('DELETE FROM recent_station_details')
+      await pgPools.evaluate.query('DELETE FROM recent_participant_subnets')
       await pgPools.evaluate.query('DELETE FROM daily_participants')
       await pgPools.evaluate.query('DELETE FROM participants')
       await pgPools.stats.query('DELETE FROM daily_scheduled_rewards')

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,21 +23,11 @@
       "dependencies": {
         "pg": "^8.12.0",
         "postgrator": "^7.2.0",
-        "spark-api": "https://github.com/filecoin-station/spark-api/archive/7075fb55b253d48d5d5eb4846f13a3f688d80437.tar.gz",
         "spark-evaluate": "filecoin-station/spark-evaluate#main"
       },
       "devDependencies": {
         "standard": "^17.1.0"
       }
-    },
-    "db/node_modules/spark-api": {
-      "name": "@filecoin-station/spark-api-monorepo",
-      "resolved": "https://github.com/filecoin-station/spark-api/archive/7075fb55b253d48d5d5eb4846f13a3f688d80437.tar.gz",
-      "license": "MIT",
-      "workspaces": [
-        "api",
-        "publish"
-      ]
     },
     "db/node_modules/spark-evaluate": {
       "resolved": "git+ssh://git@github.com/filecoin-station/spark-evaluate.git#24c5e1bcf083a40ab4a0968d427e465ace48a724",

--- a/stats/bin/migrate.js
+++ b/stats/bin/migrate.js
@@ -1,6 +1,5 @@
 import {
   getPgPools,
-  migrateApiDB,
   migrateEvaluateDB,
   migrateStatsDB
 } from '@filecoin-station/spark-stats-db'
@@ -8,4 +7,3 @@ import {
 const pgPools = await getPgPools()
 await migrateStatsDB(pgPools.stats)
 await migrateEvaluateDB(pgPools.evaluate)
-await migrateApiDB(pgPools.api)

--- a/stats/bin/spark-stats.js
+++ b/stats/bin/spark-stats.js
@@ -7,6 +7,7 @@ import { getPgPools } from '@filecoin-station/spark-stats-db'
 const {
   PORT = '8080',
   HOST = '127.0.0.1',
+  SPARK_API_BASE_URL = 'https://api.filspark.com/',
   REQUEST_LOGGING = 'true'
 } = process.env
 
@@ -17,7 +18,7 @@ const logger = {
   request: ['1', 'true'].includes(REQUEST_LOGGING) ? console.info : () => {}
 }
 
-const handler = createHandler({ pgPools, logger })
+const handler = createHandler({ SPARK_API_BASE_URL, pgPools, logger })
 const server = http.createServer(handler)
 console.log('Starting the http server on host %j port %s', HOST, PORT)
 server.listen(Number(PORT), HOST)

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -152,7 +152,5 @@ const redirectToSparkApi = async (req, res, SPARK_API_BASE_URL) => {
   res.setHeader('cache-control', `max-age=${6 * 3600}`)
 
   const location = new URL(req.url, SPARK_API_BASE_URL).toString()
-  res.setHeader('location', location)
-  res.statusCode = 302
-  res.end(location)
+  redirect(req, res, location, 302)
 }

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/node'
+import { redirect } from 'http-responders'
 
 import { getStatsWithFilterAndCaching } from './request-helpers.js'
 

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/node'
-import { json } from 'http-responders'
 
 import { getStatsWithFilterAndCaching } from './request-helpers.js'
 
@@ -22,18 +21,20 @@ import { handlePlatformRoutes } from './platform-routes.js'
 
 /**
  * @param {object} args
+ * @param {string} args.SPARK_API_BASE_URL
  * @param {import('@filecoin-station/spark-stats-db').PgPools} args.pgPools
  * @param {import('./typings.d.ts').Logger} args.logger
  * @returns
  */
 export const createHandler = ({
+  SPARK_API_BASE_URL,
   pgPools,
   logger
 }) => {
   return (req, res) => {
     const start = Date.now()
     logger.request(`${req.method} ${req.url} ...`)
-    handler(req, res, pgPools)
+    handler(req, res, pgPools, SPARK_API_BASE_URL)
       .catch(err => errorHandler(res, err, logger))
       .then(() => {
         logger.request(`${req.method} ${req.url} ${res.statusCode} (${Date.now() - start}ms)`)
@@ -73,8 +74,9 @@ const createRespondWithFetchFn =
  * @param {import('node:http').IncomingMessage} req
  * @param {import('node:http').ServerResponse} res
  * @param {import('@filecoin-station/spark-stats-db').PgPools} pgPools
+ * @param {string} SPARK_API_BASE_URL
  */
-const handler = async (req, res, pgPools) => {
+const handler = async (req, res, pgPools, SPARK_API_BASE_URL) => {
   // Caveat! `new URL('//foo', 'http://127.0.0.1')` would produce "http://foo/" - not what we want!
   const { pathname, searchParams } = new URL(`http://127.0.0.1${req.url}`)
   const segs = pathname.split('/').filter(Boolean)
@@ -102,11 +104,11 @@ const handler = async (req, res, pgPools) => {
   } else if (req.method === 'GET' && url === '/miners/retrieval-success-rate/summary') {
     await respond(fetchMinersRSRSummary)
   } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'deals' && segs[3] === 'eligible' && segs[4] === 'summary') {
-    await getRetrievableDealsForMiner(req, res, pgPools.api, segs[1])
+    await redirectToSparkApi(req, res, SPARK_API_BASE_URL)
   } else if (req.method === 'GET' && segs[0] === 'client' && segs[1] && segs[2] === 'deals' && segs[3] === 'eligible' && segs[4] === 'summary') {
-    await getRetrievableDealsForClient(req, res, pgPools.api, segs[1])
+    await redirectToSparkApi(req, res, SPARK_API_BASE_URL)
   } else if (req.method === 'GET' && segs[0] === 'allocator' && segs[1] && segs[2] === 'deals' && segs[3] === 'eligible' && segs[4] === 'summary') {
-    await getRetrievableDealsForAllocator(req, res, pgPools.api, segs[1])
+    await redirectToSparkApi(req, res, SPARK_API_BASE_URL)
   } else if (await handlePlatformRoutes(req, res, pgPools)) {
     // no-op, request was handled by handlePlatformRoute
   } else if (req.method === 'GET' && url === '/') {
@@ -141,86 +143,18 @@ const notFound = (res) => {
 }
 
 /**
- * @param {import('node:http').IncomingMessage} _req
+ * @param {import('node:http').IncomingMessage} req
  * @param {import('node:http').ServerResponse} res
- * @param {PgPools['api']} client
- * @param {string} minerId
+ * @param {string} SPARK_API_BASE_URL
  */
-const getRetrievableDealsForMiner = async (_req, res, client, minerId) => {
-  /** @type {{rows: {client_id: string; deal_count: number}[]}} */
-  const { rows } = await client.query(`
-    SELECT client_id, COUNT(cid)::INTEGER as deal_count FROM retrievable_deals
-    WHERE miner_id = $1 AND expires_at > now()
-    GROUP BY client_id
-    ORDER BY deal_count DESC, client_id ASC
-    `, [
-    minerId
-  ])
-
+const redirectToSparkApi = async (req, res, SPARK_API_BASE_URL) => {
+  console.log('SPARK_API_BASE_URL', SPARK_API_BASE_URL)
+  console.log('req.url', req.url)
   // Cache the response for 6 hours
   res.setHeader('cache-control', `max-age=${6 * 3600}`)
 
-  const body = {
-    minerId,
-    dealCount: rows.reduce((sum, row) => sum + row.deal_count, 0),
-    clients:
-      rows.map(
-        // eslint-disable-next-line camelcase
-        ({ client_id, deal_count }) => ({ clientId: client_id, dealCount: deal_count })
-      )
-  }
-
-  json(res, body)
-}
-
-const getRetrievableDealsForClient = async (_req, res, client, clientId) => {
-  /** @type {{rows: {miner_id: string; deal_count: number}[]}} */
-  const { rows } = await client.query(`
-    SELECT miner_id, COUNT(cid)::INTEGER as deal_count FROM retrievable_deals
-    WHERE client_id = $1 AND expires_at > now()
-    GROUP BY miner_id
-    ORDER BY deal_count DESC, miner_id ASC
-    `, [
-    clientId
-  ])
-
-  // Cache the response for 6 hours
-  res.setHeader('cache-control', `max-age=${6 * 3600}`)
-
-  const body = {
-    clientId,
-    dealCount: rows.reduce((sum, row) => sum + row.deal_count, 0),
-    providers: rows.map(
-      // eslint-disable-next-line camelcase
-      ({ miner_id, deal_count }) => ({ minerId: miner_id, dealCount: deal_count })
-    )
-  }
-  json(res, body)
-}
-
-const getRetrievableDealsForAllocator = async (_req, res, client, allocatorId) => {
-  /** @type {{rows: {client_id: string; deal_count: number}[]}} */
-  const { rows } = await client.query(`
-    SELECT ac.client_id, COUNT(cid)::INTEGER as deal_count
-    FROM allocator_clients ac
-    LEFT JOIN retrievable_deals rd ON ac.client_id = rd.client_id
-    WHERE ac.allocator_id = $1 AND expires_at > now()
-    GROUP BY ac.client_id
-    ORDER BY deal_count DESC, ac.client_id ASC
-    `, [
-    allocatorId
-  ])
-
-  // Cache the response for 6 hours
-  res.setHeader('cache-control', `max-age=${6 * 3600}`)
-
-  const body = {
-    allocatorId,
-    dealCount: rows.reduce((sum, row) => sum + row.deal_count, 0),
-    clients: rows.map(
-      // eslint-disable-next-line camelcase
-      ({ client_id, deal_count }) => ({ clientId: client_id, dealCount: deal_count })
-    )
-  }
-  json(res, body)
+  const location = new URL(req.url, SPARK_API_BASE_URL).toString()
+  res.setHeader('location', location)
+  res.statusCode = 302
+  res.end(location)
 }

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -105,11 +105,11 @@ const handler = async (req, res, pgPools, SPARK_API_BASE_URL) => {
   } else if (req.method === 'GET' && url === '/miners/retrieval-success-rate/summary') {
     await respond(fetchMinersRSRSummary)
   } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'deals' && segs[3] === 'eligible' && segs[4] === 'summary') {
-    await redirectToSparkApi(req, res, SPARK_API_BASE_URL)
+    redirectToSparkApi(req, res, SPARK_API_BASE_URL)
   } else if (req.method === 'GET' && segs[0] === 'client' && segs[1] && segs[2] === 'deals' && segs[3] === 'eligible' && segs[4] === 'summary') {
-    await redirectToSparkApi(req, res, SPARK_API_BASE_URL)
+    redirectToSparkApi(req, res, SPARK_API_BASE_URL)
   } else if (req.method === 'GET' && segs[0] === 'allocator' && segs[1] && segs[2] === 'deals' && segs[3] === 'eligible' && segs[4] === 'summary') {
-    await redirectToSparkApi(req, res, SPARK_API_BASE_URL)
+    redirectToSparkApi(req, res, SPARK_API_BASE_URL)
   } else if (await handlePlatformRoutes(req, res, pgPools)) {
     // no-op, request was handled by handlePlatformRoute
   } else if (req.method === 'GET' && url === '/') {
@@ -148,7 +148,7 @@ const notFound = (res) => {
  * @param {import('node:http').ServerResponse} res
  * @param {string} SPARK_API_BASE_URL
  */
-const redirectToSparkApi = async (req, res, SPARK_API_BASE_URL) => {
+const redirectToSparkApi = (req, res, SPARK_API_BASE_URL) => {
   // Cache the response for 6 hours
   res.setHeader('cache-control', `max-age=${6 * 3600}`)
 

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -148,8 +148,6 @@ const notFound = (res) => {
  * @param {string} SPARK_API_BASE_URL
  */
 const redirectToSparkApi = async (req, res, SPARK_API_BASE_URL) => {
-  console.log('SPARK_API_BASE_URL', SPARK_API_BASE_URL)
-  console.log('req.url', req.url)
   // Cache the response for 6 hours
   res.setHeader('cache-control', `max-age=${6 * 3600}`)
 

--- a/stats/test/handler.test.js
+++ b/stats/test/handler.test.js
@@ -23,6 +23,7 @@ describe('HTTP request handler', () => {
     pgPools = await getPgPools()
 
     const handler = createHandler({
+      SPARK_API_BASE_URL: 'https://api.filspark.com/',
       pgPools,
       logger: {
         info: debug,
@@ -434,117 +435,30 @@ describe('HTTP request handler', () => {
   })
 
   describe('summary of eligible deals', () => {
-    before(async () => {
-      await pgPools.api.query(`
-        INSERT INTO retrievable_deals (cid, miner_id, client_id, expires_at)
-        VALUES
-        ('bafyone', 'f0210', 'f0800', '2100-01-01'),
-        ('bafyone', 'f0220', 'f0800', '2100-01-01'),
-        ('bafytwo', 'f0220', 'f0810', '2100-01-01'),
-        ('bafyone', 'f0230', 'f0800', '2100-01-01'),
-        ('bafytwo', 'f0230', 'f0800', '2100-01-01'),
-        ('bafythree', 'f0230', 'f0810', '2100-01-01'),
-        ('bafyfour', 'f0230', 'f0820', '2100-01-01'),
-        ('bafyexpired', 'f0230', 'f0800', '2020-01-01')
-        ON CONFLICT DO NOTHING
-      `)
-
-      await pgPools.api.query(`
-        INSERT INTO allocator_clients (allocator_id, client_id)
-        VALUES
-        ('f0500', 'f0800'),
-        ('f0500', 'f0810'),
-        ('f0520', 'f0820')
-        ON CONFLICT DO NOTHING
-      `)
-    })
-
     describe('GET /miner/{id}/deals/eligible/summary', () => {
-      it('returns deal counts grouped by client id', async () => {
-        const res = await fetch(new URL('/miner/f0230/deals/eligible/summary', baseUrl))
-        await assertResponseStatus(res, 200)
+      it('redirects to spark-api', async () => {
+        const res = await fetch(new URL('/miner/f0230/deals/eligible/summary', baseUrl), { redirect: 'manual' })
+        await assertResponseStatus(res, 302)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
-        const body = await res.json()
-        assert.deepStrictEqual(body, {
-          minerId: 'f0230',
-          dealCount: 4,
-          clients: [
-            { clientId: 'f0800', dealCount: 2 },
-            { clientId: 'f0810', dealCount: 1 },
-            { clientId: 'f0820', dealCount: 1 }
-          ]
-        })
-      })
-
-      it('returns an empty array for miners with no deals in our DB', async () => {
-        const res = await fetch(new URL('/miner/f0000/deals/eligible/summary', baseUrl))
-        await assertResponseStatus(res, 200)
-        assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
-        const body = await res.json()
-        assert.deepStrictEqual(body, {
-          minerId: 'f0000',
-          dealCount: 0,
-          clients: []
-        })
+        assert.strictEqual(res.headers.get('location'), 'https://api.filspark.com/miner/f0230/deals/eligible/summary')
       })
     })
 
     describe('GET /client/{id}/deals/eligible/summary', () => {
-      it('returns deal counts grouped by miner id', async () => {
-        const res = await fetch(new URL('/client/f0800/deals/eligible/summary', baseUrl))
-        await assertResponseStatus(res, 200)
+      it('redirects to spark-api', async () => {
+        const res = await fetch(new URL('/client/f0800/deals/eligible/summary', baseUrl), { redirect: 'manual' })
+        await assertResponseStatus(res, 302)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
-        const body = await res.json()
-        assert.deepStrictEqual(body, {
-          clientId: 'f0800',
-          dealCount: 4,
-          providers: [
-            { minerId: 'f0230', dealCount: 2 },
-            { minerId: 'f0210', dealCount: 1 },
-            { minerId: 'f0220', dealCount: 1 }
-          ]
-        })
-      })
-
-      it('returns an empty array for miners with no deals in our DB', async () => {
-        const res = await fetch(new URL('/client/f0000/deals/eligible/summary', baseUrl))
-        await assertResponseStatus(res, 200)
-        assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
-        const body = await res.json()
-        assert.deepStrictEqual(body, {
-          clientId: 'f0000',
-          dealCount: 0,
-          providers: []
-        })
+        assert.strictEqual(res.headers.get('location'), 'https://api.filspark.com/client/f0800/deals/eligible/summary')
       })
     })
 
     describe('GET /allocator/{id}/deals/eligible/summary', () => {
-      it('returns deal counts grouped by client id', async () => {
-        const res = await fetch(new URL('/allocator/f0500/deals/eligible/summary', baseUrl))
-        await assertResponseStatus(res, 200)
+      it('redirects to spark-api', async () => {
+        const res = await fetch(new URL('/allocator/f0500/deals/eligible/summary', baseUrl), { redirect: 'manual' })
+        await assertResponseStatus(res, 302)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
-        const body = await res.json()
-        assert.deepStrictEqual(body, {
-          allocatorId: 'f0500',
-          dealCount: 6,
-          clients: [
-            { clientId: 'f0800', dealCount: 4 },
-            { clientId: 'f0810', dealCount: 2 }
-          ]
-        })
-      })
-
-      it('returns an empty array for miners with no deals in our DB', async () => {
-        const res = await fetch(new URL('/allocator/f0000/deals/eligible/summary', baseUrl))
-        await assertResponseStatus(res, 200)
-        assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
-        const body = await res.json()
-        assert.deepStrictEqual(body, {
-          allocatorId: 'f0000',
-          dealCount: 0,
-          clients: []
-        })
+        assert.strictEqual(res.headers.get('location'), 'https://api.filspark.com/allocator/f0500/deals/eligible/summary')
       })
     })
   })

--- a/stats/test/platform-routes.test.js
+++ b/stats/test/platform-routes.test.js
@@ -23,6 +23,7 @@ describe('Platform Routes HTTP request handler', () => {
     pgPools = await getPgPools()
 
     const handler = createHandler({
+      SPARK_API_BASE_URL: 'https://api.filspark.com/',
       pgPools,
       logger: {
         info: debug,
@@ -251,7 +252,7 @@ describe('Platform Routes HTTP request handler', () => {
     const setupScheduledRewardsData = async () => {
       await pgPools.stats.query(`
         INSERT INTO daily_scheduled_rewards (day, participant_address, scheduled_rewards)
-        VALUES 
+        VALUES
           ('${yesterday()}', 'address1', 10),
           ('${yesterday()}', 'address2', 20),
           ('${yesterday()}', 'address3', 30),
@@ -347,7 +348,7 @@ const givenDailyStationMetrics = async (pgPoolEvaluate, day, stationStats) => {
       accepted_measurement_count,
       total_measurement_count
     )
-    SELECT 
+    SELECT
       $1 AS day,
       UNNEST($2::text[]) AS station_id,
       UNNEST($3::text[]) AS participant_address,


### PR DESCRIPTION
Rework the endpoints `{miner/client/allocator}/:id/deals/eligible/summary` to return a (temporary) redirect to spark-api, as discussed in https://github.com/filecoin-station/spark-stats/pull/194#discussion_r1713500083.

Links:
- https://github.com/filecoin-station/spark-api/pull/403
- https://github.com/filecoin-station/spark/issues/78
