### PR TITLE
chore: upgrade spark-evaluate dependency

### DIFF
--- a/observer/test/observer.test.js
+++ b/observer/test/observer.test.js
@@ -128,6 +128,8 @@ describe('observer', () => {
 
   describe('observeScheduledRewards', () => {
     beforeEach(async () => {
+      await pgPools.evaluate.query('DELETE FROM recent_station_details')
+      await pgPools.evaluate.query('DELETE FROM recent_participant_subnets')
       await pgPools.evaluate.query('DELETE FROM daily_participants')
       await pgPools.evaluate.query('DELETE FROM participants')
       await pgPools.stats.query('DELETE FROM daily_scheduled_rewards')

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
       ]
     },
     "db/node_modules/spark-evaluate": {
-      "resolved": "git+ssh://git@github.com/filecoin-station/spark-evaluate.git#24c5e1bcf083a40ab4a0968d427e465ace48a724",
+      "resolved": "git+ssh://git@github.com/filecoin-station/spark-evaluate.git#3b31a57a483fba5d61e1b280b695dcf1ba73d04e",
       "dependencies": {
         "@filecoin-station/spark-impact-evaluator": "^1.1.1",
         "@glif/filecoin-address": "^3.0.7",


### PR DESCRIPTION
@PatrickNercessian FYI, this pull request updates the dependency version to include https://github.com/filecoin-station/spark-evaluate/pull/311

How to upgrade your local checkout in case of problems:

```bash
rm -rf db/node_modules/spark-evaluate && npm ci
```