### PR TITLE
fix: sum deal stats over miners and clients

### DIFF
--- a/stats/lib/stats-fetchers.js
+++ b/stats/lib/stats-fetchers.js
@@ -44,8 +44,7 @@ export const fetchDailyDealStats = async (pgPools, filter) => {
       SUM(retrieval_majority_found) AS "retrievalMajorityFound",
       SUM(retrievable) AS retrievable
     FROM daily_deals
-    WHERE day >= date_trunc('day', $1::DATE)
-      AND day <= date_trunc('day', $2::DATE)
+    WHERE day >= $1 AND day <= $2
     GROUP BY day
     ORDER BY day
     `, [

--- a/stats/lib/stats-fetchers.js
+++ b/stats/lib/stats-fetchers.js
@@ -37,14 +37,16 @@ export const fetchDailyDealStats = async (pgPools, filter) => {
   const { rows } = await pgPools.evaluate.query(`
     SELECT
       day::text,
-      tested,
-      index_majority_found AS "indexMajorityFound",
-      indexed,
-      indexed_http AS "indexedHttp",
-      retrieval_majority_found AS "retrievalMajorityFound",
-      retrievable
+      SUM(tested) AS tested,
+      SUM(index_majority_found) AS "indexMajorityFound",
+      SUM(indexed) AS indexed,
+      SUM(indexed_http) AS "indexedHttp",
+      SUM(retrieval_majority_found) AS "retrievalMajorityFound",
+      SUM(retrievable) AS retrievable
     FROM daily_deals
-    WHERE day >= $1 AND day <= $2
+    WHERE day >= date_trunc('day', $1::DATE)
+      AND day <= date_trunc('day', $2::DATE)
+    GROUP BY day
     ORDER BY day
     `, [
     filter.from,


### PR DESCRIPTION
This is a follow-up for the PR linked below to fix the output of the endpoint
`GET /deals/daily`.

- https://github.com/filecoin-station/spark-evaluate/pull/336
- https://github.com/filecoin-station/spark-stats/pull/215

Roadmap task:
- https://github.com/space-meridian/roadmap/issues/156
