### PR TITLE
feat: enable Sentry Performance Profiling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1647,6 +1647,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/@sentry/profiling-node": {
+      "version": "8.39.0",
+      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-8.39.0.tgz",
+      "integrity": "sha512-0/xHWEkB40IRUs5p3UAdIw28HxG9j1vprWno9SLKXZ2e7zNpz7MZmtOKdiXcs/uzOCcxW069sENf9uue5WqOxA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@sentry/core": "8.39.0",
+        "@sentry/node": "8.39.0",
+        "@sentry/types": "8.39.0",
+        "@sentry/utils": "8.39.0",
+        "detect-libc": "^2.0.2",
+        "node-abi": "^3.61.0"
+      },
+      "bin": {
+        "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/@sentry/types": {
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.39.0.tgz",
@@ -2476,6 +2496,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -4587,6 +4615,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-abi": {
+      "version": "3.71.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.71.0.tgz",
+      "integrity": "sha512-SZ40vRiy/+wRTf21hxkkEjPJZpARzUMVcJoQse2EF8qkUWbbO2z7vd5oA/H6bVH6SZQ5STGcu0KRDS7biNRfxw==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "dev": true,
@@ -6358,6 +6408,7 @@
       "dependencies": {
         "@filecoin-station/spark-stats-db": "^1.0.0",
         "@sentry/node": "^8.39.0",
+        "@sentry/profiling-node": "^8.39.0",
         "debug": "^4.3.7",
         "http-assert": "^1.5.0",
         "http-responders": "^2.0.2",

--- a/stats/lib/instrument.js
+++ b/stats/lib/instrument.js
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/node'
+import { nodeProfilingIntegration } from '@sentry/profiling-node';
 import fs from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -20,5 +21,10 @@ Sentry.init({
   dsn: 'https://47b65848a6171ecd8bf9f5395a782b3f@o1408530.ingest.sentry.io/4506576125427712',
   release: pkg.version,
   environment: SENTRY_ENVIRONMENT,
-  tracesSampleRate: 0.1
+  integrations: [
+    nodeProfilingIntegration(),
+  ],
+  tracesSampleRate: 0.1,
+  // Set sampling rate for performance profiling. This is relative to tracesSampleRate.
+  profilesSampleRate: 1.0,
 })

--- a/stats/package.json
+++ b/stats/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@filecoin-station/spark-stats-db": "^1.0.0",
     "@sentry/node": "^8.39.0",
+    "@sentry/profiling-node": "^8.39.0",
     "debug": "^4.3.7",
     "http-assert": "^1.5.0",
     "http-responders": "^2.0.2",


### PR DESCRIPTION
Setup Sentry Performance Profiling for spark-stats to allow us to learn why
are we hitting Fly's CPU throttling limits. Depending on the outcome of this
experiment, we can roll out profiling to other services, e.g. spark-observer.

Sentry docs:
- https://docs.sentry.io/platforms/javascript/guides/node/tracing/
- https://docs.sentry.io/platforms/javascript/guides/node/tracing/instrumentation/automatic-instrumentation/
