### PR TITLE
Add accumulative daily participants

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Base URL: http://stats.filspark.com/
 
   http://stats.filspark.com/participants/monthly
 
+- `GET /participants/accumulative/daily?from=<day>&to=<day>`
+
+  http://stats.filspark.com/participants/accumulative/daily
+
 - `GET /participants/change-rates?from=<day>&to=<day>`
 
   http://stats.filspark.com/participants/change-rates

--- a/stats/lib/platform-routes.js
+++ b/stats/lib/platform-routes.js
@@ -7,7 +7,8 @@ import {
   fetchTopEarningParticipants,
   fetchParticipantsWithTopMeasurements,
   fetchDailyStationMeasurementCounts,
-  fetchParticipantsSummary
+  fetchParticipantsSummary,
+  fetchAccumulativeDailyParticipantCount
 } from './platform-stats-fetchers.js'
 
 const createRespondWithFetchFn = (pathname, searchParams, res) => (pgPool, fetchFn) => {
@@ -40,6 +41,8 @@ export const handlePlatformRoutes = async (req, res, pgPools) => {
     await respond(pgPools.stats, fetchTopEarningParticipants)
   } else if (req.method === 'GET' && url === '/participants/summary') {
     await respondWithParticipantsSummary(res, pgPools)
+  } else if (req.method === 'GET' && url === '/participants/accumulative/daily') {
+    await respond(pgPools.evaluate, fetchAccumulativeDailyParticipantCount)
   } else if (req.method === 'GET' && url === '/transfers/daily') {
     await respond(pgPools.stats, fetchDailyRewardTransfers)
   } else {

--- a/stats/lib/platform-stats-fetchers.js
+++ b/stats/lib/platform-stats-fetchers.js
@@ -83,17 +83,10 @@ export const fetchDailyRewardTransfers = async (pgPool, filter) => {
  */
 export const fetchAccumulativeDailyParticipantCount = async (pgPool, filter) => {
   const { rows } = await pgPool.query(`
-    WITH daily_participants_count AS (
-      SELECT
-        day,
-        participant_id,
-        ROW_NUMBER() OVER (PARTITION BY participant_id ORDER BY day) AS rn
+    WITH first_appearance AS (
+      SELECT participant_id, MIN(day) as day
       FROM daily_participants
-    ),
-    first_appearance AS (
-      SELECT day, participant_id
-      FROM daily_participants_count
-      WHERE rn = 1
+      GROUP BY participant_id
     ),
     cumulative_participants AS (
       SELECT

--- a/stats/lib/platform-stats-fetchers.js
+++ b/stats/lib/platform-stats-fetchers.js
@@ -81,6 +81,21 @@ export const fetchDailyRewardTransfers = async (pgPool, filter) => {
  * @param {Queryable} pgPool
  * @param {import('./typings.js').DateRangeFilter} filter
  */
+export const fetchAccumulativeDailyParticipantCount = async (pgPool, filter) => {
+  const { rows } = await pgPool.query(`
+    SELECT day::TEXT, COUNT(DISTINCT participant_id) as participants
+    FROM daily_participants
+    WHERE day >= $1 AND day <= $2
+    GROUP BY day
+    ORDER BY day
+  `, [filter.from, filter.to])
+  return rows
+}
+
+/**
+ * @param {Queryable} pgPool
+ * @param {import('./typings.js').DateRangeFilter} filter
+ */
 export const fetchTopEarningParticipants = async (pgPool, filter) => {
   // The query combines "transfers until filter.to" with "latest scheduled rewards as of today".
   // As a result, it produces incorrect result if `to` is different from `now()`.

--- a/stats/test/platform-routes.test.js
+++ b/stats/test/platform-routes.test.js
@@ -362,6 +362,42 @@ describe('Platform Routes HTTP request handler', () => {
       )
     })
   })
+
+  describe('GET /participants/daily', () => {
+    it('counts daily participants', async () => {
+      await givenDailyParticipants(
+        pgPools.evaluate,
+        '2000-01-01',
+        ['0x1', '0x2', '0x3']
+      )
+      await givenDailyParticipants(
+        pgPools.evaluate,
+        '2000-01-03',
+        ['0x1']
+      )
+      await givenDailyParticipants(
+        pgPools.evaluate,
+        '2000-01-04',
+        ['0x1']
+      )
+
+      const res = await fetch(
+        new URL('/participants/daily?from=2000-01-01&to=2000-01-03', baseUrl), {
+          redirect: 'manual'
+        }
+      )
+      await assertResponseStatus(res, 200)
+      const daily = await res.json()
+      assert.deepStrictEqual(daily, [
+        { day: '2000-01-01', participants: 3 },
+        { day: '2000-01-03', participants: 1 }
+      ])
+      assert.strictEqual(
+        res.headers.get('cache-control'),
+        'public, max-age=86400'
+      )
+    })
+  })
 })
 
 const givenDailyMeasurementsSummary = async (pgPoolEvaluate, summaryData) => {

--- a/stats/test/platform-routes.test.js
+++ b/stats/test/platform-routes.test.js
@@ -371,11 +371,11 @@ describe('Platform Routes HTTP request handler', () => {
         '1999-01-01',
         ['0x10', '0x20', '0x30']
       )
-      // 3 new participants -> 6
+      // 3 new participants, 1 old participant -> 6
       await givenDailyParticipants(
         pgPools.evaluate,
         '2000-01-01',
-        ['0x1', '0x2', '0x3']
+        ['0x1', '0x2', '0x3', '0x10']
       )
       // 0 new participants, 2 old participants
       await givenDailyParticipants(

--- a/stats/test/platform-routes.test.js
+++ b/stats/test/platform-routes.test.js
@@ -363,26 +363,35 @@ describe('Platform Routes HTTP request handler', () => {
     })
   })
 
-  describe('GET /participants/daily', () => {
-    it('counts daily participants', async () => {
+  describe('GET /participants/accumulative/daily', () => {
+    it('counts accumulative daily participants', async () => {
+      // 3 new participants
       await givenDailyParticipants(
         pgPools.evaluate,
         '2000-01-01',
         ['0x1', '0x2', '0x3']
       )
+      // 0 new participants, 2 old participants
+      await givenDailyParticipants(
+        pgPools.evaluate,
+        '2000-01-02',
+        ['0x1', '0x2']
+      )
+      // 1 new participant, 1 old participant
       await givenDailyParticipants(
         pgPools.evaluate,
         '2000-01-03',
-        ['0x1']
+        ['0x1', '0x4']
       )
+      // out of range
       await givenDailyParticipants(
         pgPools.evaluate,
         '2000-01-04',
-        ['0x1']
+        ['0x5']
       )
 
       const res = await fetch(
-        new URL('/participants/daily?from=2000-01-01&to=2000-01-03', baseUrl), {
+        new URL('/participants/accumulative/daily?from=2000-01-01&to=2000-01-03', baseUrl), {
           redirect: 'manual'
         }
       )
@@ -390,11 +399,11 @@ describe('Platform Routes HTTP request handler', () => {
       const daily = await res.json()
       assert.deepStrictEqual(daily, [
         { day: '2000-01-01', participants: 3 },
-        { day: '2000-01-03', participants: 1 }
+        { day: '2000-01-03', participants: 4 }
       ])
       assert.strictEqual(
         res.headers.get('cache-control'),
-        'public, max-age=86400'
+        'public, max-age=31536000, immutable'
       )
     })
   })

--- a/stats/test/platform-routes.test.js
+++ b/stats/test/platform-routes.test.js
@@ -365,7 +365,13 @@ describe('Platform Routes HTTP request handler', () => {
 
   describe('GET /participants/accumulative/daily', () => {
     it('counts accumulative daily participants', async () => {
-      // 3 new participants
+      // 3 new participants, out of range
+      await givenDailyParticipants(
+        pgPools.evaluate,
+        '1999-01-01',
+        ['0x10', '0x20', '0x30']
+      )
+      // 3 new participants -> 6
       await givenDailyParticipants(
         pgPools.evaluate,
         '2000-01-01',
@@ -377,13 +383,13 @@ describe('Platform Routes HTTP request handler', () => {
         '2000-01-02',
         ['0x1', '0x2']
       )
-      // 1 new participant, 1 old participant
+      // 1 new participant, 1 old participant -> 7
       await givenDailyParticipants(
         pgPools.evaluate,
         '2000-01-03',
         ['0x1', '0x4']
       )
-      // out of range
+      // 1 new participant, out of range
       await givenDailyParticipants(
         pgPools.evaluate,
         '2000-01-04',
@@ -398,8 +404,8 @@ describe('Platform Routes HTTP request handler', () => {
       await assertResponseStatus(res, 200)
       const daily = await res.json()
       assert.deepStrictEqual(daily, [
-        { day: '2000-01-01', participants: 3 },
-        { day: '2000-01-03', participants: 4 }
+        { day: '2000-01-01', participants: 6 },
+        { day: '2000-01-03', participants: 7 }
       ])
       assert.strictEqual(
         res.headers.get('cache-control'),


### PR DESCRIPTION
For https://github.com/space-meridian/roadmap/issues/154#issuecomment-2511707545

https://chat.mistral.ai/chat/4c43d4a1-2126-4e17-b65c-8ba40afac14a

I modified to add `DISTINCT(day::TEXT)`, as we were otherwise getting redundant rows. I also changed `cumulative_participants` to an `INT` and renamed it to `participants`