### PR TITLE
Add individual daily transfers. Closes #253

### DIFF
--- a/stats/lib/platform-stats-fetchers.js
+++ b/stats/lib/platform-stats-fetchers.js
@@ -3,6 +3,8 @@ import { today, yesterday } from './request-helpers.js'
 
 /** @typedef {import('@filecoin-station/spark-stats-db').Queryable} Queryable */
 
+const ONE_DAY = 24 * 60 * 60 * 1000
+
 /**
  * @param {Queryable} pgPool
  * @param {import('./typings.js').DateRangeFilter} filter
@@ -67,6 +69,11 @@ export const fetchParticipantsWithTopMeasurements = async (pgPool, filter) => {
  * @param {import('./typings.js').DateRangeFilter} filter
  */
 export const fetchDailyRewardTransfers = async (pgPool, filter) => {
+  assert(
+    new Date(filter.to).getTime() - new Date(filter.from).getTime() <= 31 * ONE_DAY,
+    400,
+    'Date range must be 31 days max'
+  )
   const { rows } = await pgPool.query(`
     SELECT day::TEXT, to_address, amount
     FROM daily_reward_transfers

--- a/stats/test/platform-routes.test.js
+++ b/stats/test/platform-routes.test.js
@@ -269,6 +269,17 @@ describe('Platform Routes HTTP request handler', () => {
         }
       ])
     })
+    it('returns 400 if the date range is more than 31 days', async () => {
+      const res = await fetch(
+        new URL(
+          '/transfers/daily?from=2024-01-01&to=2024-02-02',
+          baseUrl
+        ), {
+          redirect: 'manual'
+        }
+      )
+      await assertResponseStatus(res, 400)
+    })
   })
 
   describe('GET /participants/top-earning', () => {

--- a/stats/test/platform-routes.test.js
+++ b/stats/test/platform-routes.test.js
@@ -243,8 +243,30 @@ describe('Platform Routes HTTP request handler', () => {
       await assertResponseStatus(res, 200)
       const metrics = await res.json()
       assert.deepStrictEqual(metrics, [
-        { day: '2024-01-11', amount: '150' },
-        { day: '2024-01-12', amount: '550' }
+        {
+          day: '2024-01-11',
+          amount: '150',
+          transfers: [
+            {
+              toAddress: 'to2',
+              amount: '150'
+            }
+          ]
+        },
+        {
+          day: '2024-01-12',
+          amount: '550',
+          transfers: [
+            {
+              toAddress: 'to2',
+              amount: '300'
+            },
+            {
+              toAddress: 'to3',
+              amount: '250'
+            }
+          ]
+        }
       ])
     })
   })


### PR DESCRIPTION
Closes #253

With this change, we don't need to manually copy transfers into the rewards releases spreadsheet any more.