### PR TITLE
Add routes for time-to-first-byte stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7122,7 +7122,7 @@
       }
     },
     "observer/node_modules/spark-evaluate": {
-      "resolved": "git+ssh://git@github.com/filecoin-station/spark-evaluate.git#607d836f6a60b9b22c57254d6df041dcd4c1cf5f",
+      "resolved": "git+ssh://git@github.com/filecoin-station/spark-evaluate.git#d2368132e8c8987c87cb5700dc13dfeda291cd17",
       "dev": true,
       "dependencies": {
         "@filecoin-station/spark-impact-evaluator": "^1.2.4",
@@ -7169,7 +7169,7 @@
       }
     },
     "stats/node_modules/spark-evaluate": {
-      "resolved": "git+ssh://git@github.com/filecoin-station/spark-evaluate.git#607d836f6a60b9b22c57254d6df041dcd4c1cf5f",
+      "resolved": "git+ssh://git@github.com/filecoin-station/spark-evaluate.git#d2368132e8c8987c87cb5700dc13dfeda291cd17",
       "dev": true,
       "dependencies": {
         "@filecoin-station/spark-impact-evaluator": "^1.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
       }
     },
     "db/node_modules/spark-evaluate": {
-      "resolved": "git+ssh://git@github.com/filecoin-station/spark-evaluate.git#3ac022aac2d5e5df7d88d33c460b45e6567d01d6",
+      "resolved": "git+ssh://git@github.com/filecoin-station/spark-evaluate.git#d2368132e8c8987c87cb5700dc13dfeda291cd17",
       "dependencies": {
         "@filecoin-station/spark-impact-evaluator": "^1.2.4",
         "@glif/filecoin-address": "^3.0.12",

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -16,8 +16,7 @@ import {
   fetchDailyRetrievalResultCodes,
   fetchDailyMinerRSRSummary,
   fetchDailyRetrievalTimes,
-  fetchDailyMinerRetrievalTimes,
-  fetchRetrievalTimesSummary
+  fetchDailyMinerRetrievalTimes
 } from './stats-fetchers.js'
 
 import { handlePlatformRoutes } from './platform-routes.js'
@@ -111,8 +110,6 @@ const handler = async (req, res, pgPools, SPARK_API_BASE_URL) => {
     await respond(fetchMinersRSRSummary)
   } else if (req.method === 'GET' && url === '/retrieval-result-codes/daily') {
     await respond(fetchDailyRetrievalResultCodes)
-  } else if (req.method === 'GET' && url === '/retrieval-times/summary') {
-    await respond(fetchRetrievalTimesSummary)
   } else if (req.method === 'GET' && url === '/retrieval-times/daily') {
     await respond(fetchDailyRetrievalTimes)
   } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'retrieval-times' && segs[3] === 'summary') {

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -15,9 +15,9 @@ import {
   fetchDealSummary,
   fetchDailyRetrievalResultCodes,
   fetchDailyMinerRSRSummary,
-  fetchDailyTTFBStats,
-  fetchDailyMinerTTFBStats,
-  fetchTTFBSummary
+  fetchDailyRetrievalTimes,
+  fetchDailyMinerRetrievalTimes,
+  fetchRetrievalTimesSummary
 } from './stats-fetchers.js'
 
 import { handlePlatformRoutes } from './platform-routes.js'
@@ -111,12 +111,12 @@ const handler = async (req, res, pgPools, SPARK_API_BASE_URL) => {
     await respond(fetchMinersRSRSummary)
   } else if (req.method === 'GET' && url === '/retrieval-result-codes/daily') {
     await respond(fetchDailyRetrievalResultCodes)
-  } else if (req.method === 'GET' && url === '/ttfb/summary') {
-    await respond(fetchTTFBSummary)
-  } else if (req.method === 'GET' && url === '/ttfb/daily') {
-    await respond(fetchDailyTTFBStats)
-  } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'ttfb' && segs[3] === 'summary') {
-    await respond(fetchDailyMinerTTFBStats, segs[1])
+  } else if (req.method === 'GET' && url === '/retrieval-times/summary') {
+    await respond(fetchRetrievalTimesSummary)
+  } else if (req.method === 'GET' && url === '/retrieval-times/daily') {
+    await respond(fetchDailyRetrievalTimes)
+  } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'retrieval-times' && segs[3] === 'summary') {
+    await respond(fetchDailyMinerRetrievalTimes, segs[1])
   } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'retrieval-success-rate' && segs[3] === 'summary') {
     await respond(fetchDailyMinerRSRSummary, segs[1])
   } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'deals' && segs[3] === 'eligible' && segs[4] === 'summary') {

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -14,7 +14,10 @@ import {
   fetchRetrievalSuccessRate,
   fetchDealSummary,
   fetchDailyRetrievalResultCodes,
-  fetchDailyMinerRSRSummary
+  fetchDailyMinerRSRSummary,
+  fetchDailyTTFBStats,
+  fetchDailyMinerTTFBStats,
+  fetchTTFBSummary
 } from './stats-fetchers.js'
 
 import { handlePlatformRoutes } from './platform-routes.js'
@@ -108,6 +111,12 @@ const handler = async (req, res, pgPools, SPARK_API_BASE_URL) => {
     await respond(fetchMinersRSRSummary)
   } else if (req.method === 'GET' && url === '/retrieval-result-codes/daily') {
     await respond(fetchDailyRetrievalResultCodes)
+  } else if (req.method === 'GET' && url === '/ttfb/summary') {
+    await respond(fetchTTFBSummary)
+  } else if (req.method === 'GET' && url === '/ttfb/daily') {
+    await respond(fetchDailyTTFBStats)
+  } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'ttfb' && segs[3] === 'summary') {
+    await respond(fetchDailyMinerTTFBStats, segs[1])
   } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'retrieval-success-rate' && segs[3] === 'summary') {
     await respond(fetchDailyMinerRSRSummary, segs[1])
   } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'deals' && segs[3] === 'eligible' && segs[4] === 'summary') {

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -15,8 +15,8 @@ import {
   fetchDealSummary,
   fetchDailyRetrievalResultCodes,
   fetchDailyMinerRSRSummary,
-  fetchDailyRetrievalTimes,
-  fetchDailyMinerRetrievalTimes
+  fetchDailyRetrievalTimings,
+  fetchDailyMinerRetrievalTimings
 } from './stats-fetchers.js'
 
 import { handlePlatformRoutes } from './platform-routes.js'
@@ -110,10 +110,10 @@ const handler = async (req, res, pgPools, SPARK_API_BASE_URL) => {
     await respond(fetchMinersRSRSummary)
   } else if (req.method === 'GET' && url === '/retrieval-result-codes/daily') {
     await respond(fetchDailyRetrievalResultCodes)
-  } else if (req.method === 'GET' && url === '/retrieval-times/daily') {
-    await respond(fetchDailyRetrievalTimes)
-  } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'retrieval-times' && segs[3] === 'summary') {
-    await respond(fetchDailyMinerRetrievalTimes, segs[1])
+  } else if (req.method === 'GET' && url === '/retrieval-timings/daily') {
+    await respond(fetchDailyRetrievalTimings)
+  } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'retrieval-timings' && segs[3] === 'summary') {
+    await respond(fetchDailyMinerRetrievalTimings, segs[1])
   } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'retrieval-success-rate' && segs[3] === 'summary') {
     await respond(fetchDailyMinerRSRSummary, segs[1])
   } else if (req.method === 'GET' && segs[0] === 'miner' && segs[1] && segs[2] === 'deals' && segs[3] === 'eligible' && segs[4] === 'summary') {

--- a/stats/lib/stats-fetchers.js
+++ b/stats/lib/stats-fetchers.js
@@ -292,29 +292,29 @@ export const fetchDailyRetrievalResultCodes = async (pgPools, filter) => {
 }
 
 /**
- * Fetches global median time-to-first-byte
+ * Fetches global retrieval time statistics
  * @param {import('@filecoin-station/spark-stats-db').PgPools} pgPools
  * @param {import('./typings.js').DateRangeFilter} filter
  */
-export const fetchTTFBSummary = async (pgPools, filter) => {
+export const fetchRetrievalTimesSummary = async (pgPools, filter) => {
   const { rows } = await pgPools.evaluate.query(`
-    SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY ttfb_median) AS p50 
-    FROM ttfb_retreival_stats
+    SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY time_to_first_byte_p50) AS ttfb_p50 
+    FROM retrieval_times
   `)
   return rows
 }
 
 /**
- * Fetches daily global median time-to-first-byte
+ * Fetches daily global retrieval time statistics
  * @param {import('@filecoin-station/spark-stats-db').PgPools} pgPools
  * @param {import('./typings.js').DateRangeFilter} filter
  */
-export const fetchDailyTTFBStats = async (pgPools, filter) => {
+export const fetchDailyRetrievalTimes = async (pgPools, filter) => {
   const { rows } = await pgPools.evaluate.query(`
     SELECT
       day::text,
-      percentile_cont(0.5) WITHIN GROUP (ORDER BY ttfb_median) AS p50
-    FROM ttfb_retreival_stats
+      percentile_cont(0.5) WITHIN GROUP (ORDER BY time_to_first_byte_p50) AS ttfb_p50
+    FROM retrieval_times
     WHERE day >= $1 AND day <= $2
     GROUP BY day
     ORDER BY day
@@ -326,18 +326,18 @@ export const fetchDailyTTFBStats = async (pgPools, filter) => {
 }
 
 /**
- * Fetches per miner median time-to-first-byte
+ * Fetches per miner daily retrieval time statistics
  * @param {import('@filecoin-station/spark-stats-db').PgPools} pgPools
  * @param {import('./typings.js').DateRangeFilter} filter
  * @param {string} minerId
  */
-export const fetchDailyMinerTTFBStats = async (pgPools, { from, to }, minerId) => {
+export const fetchDailyMinerRetrievalTimes = async (pgPools, { from, to }, minerId) => {
   const { rows } = await pgPools.evaluate.query(`
     SELECT
       day::text,
       miner_id,
-      percentile_cont(0.5) WITHIN GROUP (ORDER BY ttfb_median) AS p50
-    FROM ttfb_retreival_stats
+      percentile_cont(0.5) WITHIN GROUP (ORDER BY time_to_first_byte_p50) AS ttfb_p50
+    FROM retrieval_times
     WHERE miner_id = $1 AND day >= $2 AND day <= $3
     GROUP BY day, miner_id
     ORDER BY day

--- a/stats/lib/stats-fetchers.js
+++ b/stats/lib/stats-fetchers.js
@@ -292,19 +292,6 @@ export const fetchDailyRetrievalResultCodes = async (pgPools, filter) => {
 }
 
 /**
- * Fetches global retrieval time statistics
- * @param {import('@filecoin-station/spark-stats-db').PgPools} pgPools
- * @param {import('./typings.js').DateRangeFilter} filter
- */
-export const fetchRetrievalTimesSummary = async (pgPools, filter) => {
-  const { rows } = await pgPools.evaluate.query(`
-    SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY time_to_first_byte_p50) AS ttfb_p50 
-    FROM retrieval_times
-  `)
-  return rows
-}
-
-/**
  * Fetches daily global retrieval time statistics
  * @param {import('@filecoin-station/spark-stats-db').PgPools} pgPools
  * @param {import('./typings.js').DateRangeFilter} filter
@@ -339,7 +326,7 @@ export const fetchDailyMinerRetrievalTimes = async (pgPools, { from, to }, miner
       percentile_cont(0.5) WITHIN GROUP (ORDER BY time_to_first_byte_p50) AS ttfb_p50
     FROM retrieval_times
     WHERE miner_id = $1 AND day >= $2 AND day <= $3
-    GROUP BY day, miner_id
+    GROUP BY day, miner_id 
     ORDER BY day
     `, [
     minerId,

--- a/stats/lib/stats-fetchers.js
+++ b/stats/lib/stats-fetchers.js
@@ -296,12 +296,12 @@ export const fetchDailyRetrievalResultCodes = async (pgPools, filter) => {
  * @param {import('@filecoin-station/spark-stats-db').PgPools} pgPools
  * @param {import('./typings.js').DateRangeFilter} filter
  */
-export const fetchDailyRetrievalTimes = async (pgPools, filter) => {
+export const fetchDailyRetrievalTimings = async (pgPools, filter) => {
   const { rows } = await pgPools.evaluate.query(`
     SELECT
       day::text,
-      percentile_cont(0.5) WITHIN GROUP (ORDER BY time_to_first_byte_p50) AS ttfb_p50
-    FROM retrieval_times
+      CEIL(percentile_cont(0.5) WITHIN GROUP (ORDER BY ttfb_p50_values)) AS ttfb_ms
+    FROM retrieval_timings, UNNEST(ttfb_p50) AS ttfb_p50_values
     WHERE day >= $1 AND day <= $2
     GROUP BY day
     ORDER BY day
@@ -318,13 +318,13 @@ export const fetchDailyRetrievalTimes = async (pgPools, filter) => {
  * @param {import('./typings.js').DateRangeFilter} filter
  * @param {string} minerId
  */
-export const fetchDailyMinerRetrievalTimes = async (pgPools, { from, to }, minerId) => {
+export const fetchDailyMinerRetrievalTimings = async (pgPools, { from, to }, minerId) => {
   const { rows } = await pgPools.evaluate.query(`
     SELECT
       day::text,
       miner_id,
-      percentile_cont(0.5) WITHIN GROUP (ORDER BY time_to_first_byte_p50) AS ttfb_p50
-    FROM retrieval_times
+      CEIL(percentile_cont(0.5) WITHIN GROUP (ORDER BY ttfb_p50_values)) AS ttfb_ms
+    FROM retrieval_timings, UNNEST(ttfb_p50) AS ttfb_p50_values
     WHERE miner_id = $1 AND day >= $2 AND day <= $3
     GROUP BY day, miner_id 
     ORDER BY day

--- a/stats/test/handler.test.js
+++ b/stats/test/handler.test.js
@@ -48,6 +48,7 @@ describe('HTTP request handler', () => {
     await pgPools.evaluate.query('DELETE FROM retrieval_stats')
     await pgPools.evaluate.query('DELETE FROM daily_participants')
     await pgPools.evaluate.query('DELETE FROM daily_deals')
+    await pgPools.evaluate.query('DELETE FROM retrieval_times')
     await pgPools.stats.query('DELETE FROM daily_scheduled_rewards')
     await pgPools.stats.query('DELETE FROM daily_reward_transfers')
     await pgPools.stats.query('DELETE FROM daily_retrieval_result_codes')

--- a/stats/test/handler.test.js
+++ b/stats/test/handler.test.js
@@ -778,8 +778,8 @@ describe('HTTP request handler', () => {
       await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-20', minerId: 'f1one', timeToFirstByteP50: [1000] })
       await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-20', minerId: 'f1two', timeToFirstByteP50: [1000] })
 
-      await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-10', minerId: 'f1one', timeToFirstByteP50: [3000, 1000] })
-      await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-10', minerId: 'f1two', timeToFirstByteP50: [3000, 1000] })
+      await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-10', minerId: 'f1one', timeToFirstByteP50: [123, 345] })
+      await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-10', minerId: 'f1two', timeToFirstByteP50: [654, 789] })
       // after the range
       await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-21', minerId: 'f1one', timeToFirstByteP50: [1000] })
       await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-21', minerId: 'f1two', timeToFirstByteP50: [1000] })
@@ -800,7 +800,7 @@ describe('HTTP request handler', () => {
         await res.json()
       )
       assert.deepStrictEqual(stats, [
-        { day: '2024-01-10', ttfb_ms: 2000 },
+        { day: '2024-01-10', ttfb_ms: 500 },
         { day: '2024-01-20', ttfb_ms: 1000 }
       ])
     })
@@ -820,7 +820,7 @@ describe('HTTP request handler', () => {
         await res.json()
       )
       assert.deepStrictEqual(stats, [
-        { day: '2024-01-10', miner_id: 'f1one', ttfb_ms: 2000 },
+        { day: '2024-01-10', miner_id: 'f1one', ttfb_ms: 234 },
         { day: '2024-01-20', miner_id: 'f1one', ttfb_ms: 1000 }
       ])
     })

--- a/stats/test/handler.test.js
+++ b/stats/test/handler.test.js
@@ -48,7 +48,7 @@ describe('HTTP request handler', () => {
     await pgPools.evaluate.query('DELETE FROM retrieval_stats')
     await pgPools.evaluate.query('DELETE FROM daily_participants')
     await pgPools.evaluate.query('DELETE FROM daily_deals')
-    await pgPools.evaluate.query('DELETE FROM retrieval_times')
+    await pgPools.evaluate.query('DELETE FROM retrieval_timings')
     await pgPools.stats.query('DELETE FROM daily_scheduled_rewards')
     await pgPools.stats.query('DELETE FROM daily_reward_transfers')
     await pgPools.stats.query('DELETE FROM daily_retrieval_result_codes')
@@ -769,28 +769,26 @@ describe('HTTP request handler', () => {
     })
   })
 
-  describe('miner retrieval time stats', () => {
+  describe('miner retrieval timing stats', () => {
     beforeEach(async () => {
       // before the range
-      await givenRetrievalTimes(pgPools.evaluate, { day: '2024-01-09', minerId: 'f1one', taskId: 'cidone::f1one::0', timeToFirstByteP50: 1000 })
-      await givenRetrievalTimes(pgPools.evaluate, { day: '2024-01-09', minerId: 'f1two', taskId: 'cidone::f1two::0', timeToFirstByteP50: 1000 })
+      await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-09', minerId: 'f1one', timeToFirstByteP50: [1000] })
+      await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-09', minerId: 'f1two', timeToFirstByteP50: [1000] })
       // in the range
-      await givenRetrievalTimes(pgPools.evaluate, { day: '2024-01-20', minerId: 'f1one', taskId: 'cidone::f1one::1', timeToFirstByteP50: 1000 })
-      await givenRetrievalTimes(pgPools.evaluate, { day: '2024-01-20', minerId: 'f1two', taskId: 'cidone::f1two::1', timeToFirstByteP50: 1000 })
+      await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-20', minerId: 'f1one', timeToFirstByteP50: [1000] })
+      await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-20', minerId: 'f1two', timeToFirstByteP50: [1000] })
 
-      await givenRetrievalTimes(pgPools.evaluate, { day: '2024-01-10', minerId: 'f1one', taskId: 'cidone::f1one::2', timeToFirstByteP50: 3000 })
-      await givenRetrievalTimes(pgPools.evaluate, { day: '2024-01-10', minerId: 'f1two', taskId: 'cidone::f1two::2', timeToFirstByteP50: 3000 })
-      await givenRetrievalTimes(pgPools.evaluate, { day: '2024-01-10', minerId: 'f1one', taskId: 'cidone::f1one::3', timeToFirstByteP50: 1000 })
-      await givenRetrievalTimes(pgPools.evaluate, { day: '2024-01-10', minerId: 'f1two', taskId: 'cidone::f1two::3', timeToFirstByteP50: 1000 })
+      await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-10', minerId: 'f1one', timeToFirstByteP50: [3000, 1000] })
+      await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-10', minerId: 'f1two', timeToFirstByteP50: [3000, 1000] })
       // after the range
-      await givenRetrievalTimes(pgPools.evaluate, { day: '2024-01-21', minerId: 'f1one', taskId: 'cidone::f1one::4', timeToFirstByteP50: 1000 })
-      await givenRetrievalTimes(pgPools.evaluate, { day: '2024-01-21', minerId: 'f1two', taskId: 'cidone::f1two::4', timeToFirstByteP50: 1000 })
+      await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-21', minerId: 'f1one', timeToFirstByteP50: [1000] })
+      await givenRetrievalTimings(pgPools.evaluate, { day: '2024-01-21', minerId: 'f1two', timeToFirstByteP50: [1000] })
     })
 
-    it('lists daily retrieval times in given date range', async () => {
+    it('lists daily retrieval timings in given date range', async () => {
       const res = await fetch(
         new URL(
-          '/retrieval-times/daily?from=2024-01-10&to=2024-01-20',
+          '/retrieval-timings/daily?from=2024-01-10&to=2024-01-20',
           baseUrl
         ), {
           redirect: 'manual'
@@ -802,15 +800,15 @@ describe('HTTP request handler', () => {
         await res.json()
       )
       assert.deepStrictEqual(stats, [
-        { day: '2024-01-10', ttfb_p50: 2000 },
-        { day: '2024-01-20', ttfb_p50: 1000 }
+        { day: '2024-01-10', ttfb_ms: 2000 },
+        { day: '2024-01-20', ttfb_ms: 1000 }
       ])
     })
 
-    it('lists daily retrieval times summary for specified miner in given date range', async () => {
+    it('lists daily retrieval timings summary for specified miner in given date range', async () => {
       const res = await fetch(
         new URL(
-          '/miner/f1one/retrieval-times/summary?from=2024-01-10&to=2024-01-20',
+          '/miner/f1one/retrieval-timings/summary?from=2024-01-10&to=2024-01-20',
           baseUrl
         ), {
           redirect: 'manual'
@@ -822,8 +820,8 @@ describe('HTTP request handler', () => {
         await res.json()
       )
       assert.deepStrictEqual(stats, [
-        { day: '2024-01-10', miner_id: 'f1one', ttfb_p50: 2000 },
-        { day: '2024-01-20', miner_id: 'f1one', ttfb_p50: 1000 }
+        { day: '2024-01-10', miner_id: 'f1one', ttfb_ms: 2000 },
+        { day: '2024-01-20', miner_id: 'f1one', ttfb_ms: 1000 }
       ])
     })
   })
@@ -910,12 +908,11 @@ const givenDailyDealStats = async (pgPool, {
  * @param {object} data
  * @param {string} data.day
  * @param {string} data.minerId
- * @param {string} data.taskId
- * @param {number} data.timeToFirstByteP50
+ * @param {number[]} data.timeToFirstByteP50
  */
-const givenRetrievalTimes = async (pgPool, { day, minerId, taskId, timeToFirstByteP50 }) => {
+const givenRetrievalTimings = async (pgPool, { day, minerId, timeToFirstByteP50 }) => {
   await pgPool.query(
-    'INSERT INTO retrieval_times (day, miner_id, task_id, time_to_first_byte_p50) VALUES ($1, $2, $3, $4)',
-    [day, minerId ?? 'f1test', taskId ?? 'cidone::f1test::0', timeToFirstByteP50]
+    'INSERT INTO retrieval_timings (day, miner_id, ttfb_p50) VALUES ($1, $2, $3)',
+    [day, minerId ?? 'f1test', timeToFirstByteP50]
   )
 }


### PR DESCRIPTION
Adds routes for fetching global and per miner time to first byte stats.

Related to https://github.com/space-meridian/roadmap/issues/208 