### PR TITLE
Add endpoint for fetching miners timing summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,17 @@ Base URL: http://stats.filspark.com/
 
   http://stats.filspark.com/miners/retrieval-success-rate/summary
 
+- `GET /miners/retrieval-timings/summary?from=<day>&to=<day>`
+
+  http://stats.filspark.com/miners/retrieval-timings/summary
+
 - `GET /miner/:id/retrieval-success-rate/summary?from=<day>&to=<day>`
 
   http://stats.filspark.com/miner/f0814049/retrieval-success-rate/summary
+
+- `GET /miner/:id/retrieval-timings/summary?from=<day>&to=<day>`
+
+  http://stats.filspark.com/miner/f0814049/retrieval-timings/summary
 
 - `GET /miner/:id/deals/eligible/summary`
 
@@ -100,6 +108,9 @@ Base URL: http://stats.filspark.com/
   
   http://stats.filspark.com/retrieval-result-codes/daily
 
+- `GET /retrieval-timings/daily?from=2024-01-01&to=2024-01-31`
+  
+  http://stats.filspark.com/retrieval-result-codes/daily
 
 ## Development
 

--- a/stats/lib/handler.js
+++ b/stats/lib/handler.js
@@ -16,7 +16,8 @@ import {
   fetchDailyRetrievalResultCodes,
   fetchDailyMinerRSRSummary,
   fetchDailyRetrievalTimings,
-  fetchDailyMinerRetrievalTimings
+  fetchDailyMinerRetrievalTimings,
+  fetchMinersTimingsSummary
 } from './stats-fetchers.js'
 
 import { handlePlatformRoutes } from './platform-routes.js'
@@ -108,6 +109,8 @@ const handler = async (req, res, pgPools, SPARK_API_BASE_URL) => {
     await respond(fetchParticipantRewardTransfers, segs[1])
   } else if (req.method === 'GET' && url === '/miners/retrieval-success-rate/summary') {
     await respond(fetchMinersRSRSummary)
+  } else if (req.method === 'GET' && url === '/miners/retrieval-timings/summary') {
+    await respond(fetchMinersTimingsSummary)
   } else if (req.method === 'GET' && url === '/retrieval-result-codes/daily') {
     await respond(fetchDailyRetrievalResultCodes)
   } else if (req.method === 'GET' && url === '/retrieval-timings/daily') {

--- a/stats/lib/stats-fetchers.js
+++ b/stats/lib/stats-fetchers.js
@@ -344,13 +344,12 @@ export const fetchDailyMinerRetrievalTimings = async (pgPools, { from, to }, min
 export const fetchMinersTimingsSummary = async (pgPools, { from, to }) => {
   const { rows } = await pgPools.evaluate.query(`
     SELECT
-      day::text,
       miner_id,
       CEIL(percentile_cont(0.5) WITHIN GROUP (ORDER BY ttfb_p50_values)) AS ttfb_ms
     FROM retrieval_timings, UNNEST(ttfb_p50) AS ttfb_p50_values
     WHERE day >= $1 AND day <= $2
-    GROUP BY day, miner_id 
-    ORDER BY day
+    GROUP BY miner_id 
+    ORDER BY miner_id
     `, [
     from,
     to

--- a/stats/lib/stats-fetchers.js
+++ b/stats/lib/stats-fetchers.js
@@ -335,3 +335,25 @@ export const fetchDailyMinerRetrievalTimings = async (pgPools, { from, to }, min
   ])
   return rows
 }
+
+/**
+ * Fetches retrieval time statistics summary for all miners for given date range.
+ * @param {import('@filecoin-station/spark-stats-db').PgPools} pgPools
+ * @param {import('./typings.js').DateRangeFilter} filter
+ */
+export const fetchMinersTimingsSummary = async (pgPools, { from, to }) => {
+  const { rows } = await pgPools.evaluate.query(`
+    SELECT
+      day::text,
+      miner_id,
+      CEIL(percentile_cont(0.5) WITHIN GROUP (ORDER BY ttfb_p50_values)) AS ttfb_ms
+    FROM retrieval_timings, UNNEST(ttfb_p50) AS ttfb_p50_values
+    WHERE day >= $1 AND day <= $2
+    GROUP BY day, miner_id 
+    ORDER BY day
+    `, [
+    from,
+    to
+  ])
+  return rows
+}

--- a/stats/test/handler.test.js
+++ b/stats/test/handler.test.js
@@ -840,10 +840,8 @@ describe('HTTP request handler', () => {
         await res.json()
       )
       assert.deepStrictEqual(stats, [
-        { day: '2024-01-10', miner_id: 'f1one', ttfb_ms: 234 },
-        { day: '2024-01-10', miner_id: 'f1two', ttfb_ms: 722 },
-        { day: '2024-01-20', miner_id: 'f1one', ttfb_ms: 1000 },
-        { day: '2024-01-20', miner_id: 'f1two', ttfb_ms: 1000 }
+        { miner_id: 'f1one', ttfb_ms: 345 },
+        { miner_id: 'f1two', ttfb_ms: 789 }
       ])
     })
   })

--- a/stats/test/handler.test.js
+++ b/stats/test/handler.test.js
@@ -824,6 +824,28 @@ describe('HTTP request handler', () => {
         { day: '2024-01-20', miner_id: 'f1one', ttfb_ms: 1000 }
       ])
     })
+
+    it('lists daily retrieval timings summary for all miners in given date range', async () => {
+      const res = await fetch(
+        new URL(
+          '/miners/retrieval-timings/summary?from=2024-01-10&to=2024-01-20',
+          baseUrl
+        ), {
+          redirect: 'manual'
+        }
+      )
+      await assertResponseStatus(res, 200)
+
+      const stats = /** @type {{ day: string, success_rate: number }[]} */(
+        await res.json()
+      )
+      assert.deepStrictEqual(stats, [
+        { day: '2024-01-10', miner_id: 'f1one', ttfb_ms: 234 },
+        { day: '2024-01-10', miner_id: 'f1two', ttfb_ms: 722 },
+        { day: '2024-01-20', miner_id: 'f1one', ttfb_ms: 1000 },
+        { day: '2024-01-20', miner_id: 'f1two', ttfb_ms: 1000 }
+      ])
+    })
   })
 })
 


### PR DESCRIPTION
Introduces an endpoint to retrieve miner timing summaries. This data will be utilized to display miner TTFB in a table on the Spark dashboard's main page.

Related to https://github.com/filecoin-station/spark-dashboard/pull/14#issuecomment-2595073358
