### PR TITLE
Make spark-evaluate automatically upgradable

### DIFF
--- a/.github/workflows/dependabot-auto-approve-always.yml
+++ b/.github/workflows/dependabot-auto-approve-always.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         dependencyStartsWith:
-          - spark-evaluate
+          - '@filecoin-station/spark-evaluate'
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/db/index.js
+++ b/db/index.js
@@ -1,4 +1,4 @@
-import { migrateWithPgClient as migrateEvaluateDB } from 'spark-evaluate/lib/migrate.js'
+import { migrateWithPgClient as migrateEvaluateDB } from '@filecoin-station/spark-evaluate/lib/migrate.js'
 import pg from 'pg'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'

--- a/db/package.json
+++ b/db/package.json
@@ -12,9 +12,9 @@
     "standard": "^17.1.2"
   },
   "dependencies": {
+    "@filecoin-station/spark-evaluate": "^1.0.0",
     "pg": "^8.13.1",
-    "postgrator": "^8.0.0",
-    "spark-evaluate": "filecoin-station/spark-evaluate#main"
+    "postgrator": "^8.0.0"
   },
   "standard": {
     "env": [

--- a/db/package.json
+++ b/db/package.json
@@ -9,10 +9,10 @@
     "lint": "standard"
   },
   "devDependencies": {
-    "@filecoin-station/spark-evaluate": "^1.0.4",
     "standard": "^17.1.2"
   },
   "dependencies": {
+    "@filecoin-station/spark-evaluate": "^1.0.4",
     "pg": "^8.13.1",
     "postgrator": "^8.0.0"
   },

--- a/db/package.json
+++ b/db/package.json
@@ -9,10 +9,10 @@
     "lint": "standard"
   },
   "devDependencies": {
+    "@filecoin-station/spark-evaluate": "^1.0.4",
     "standard": "^17.1.2"
   },
   "dependencies": {
-    "@filecoin-station/spark-evaluate": "^1.0.0",
     "pg": "^8.13.1",
     "postgrator": "^8.0.0"
   },

--- a/db/test-helpers.js
+++ b/db/test-helpers.js
@@ -1,4 +1,4 @@
-import { mapParticipantsToIds } from 'spark-evaluate/lib/platform-stats.js'
+import { mapParticipantsToIds } from '@filecoin-station/spark-evaluate/lib/platform-stats.js'
 
 /**
  * @param {import('./typings.js').Queryable} pgPool

--- a/observer/package.json
+++ b/observer/package.json
@@ -10,11 +10,11 @@
     "test": "mocha"
   },
   "devDependencies": {
+    "@filecoin-station/spark-evaluate": "^1.0.4",
     "mocha": "^11.0.1",
     "standard": "^17.1.2"
   },
   "dependencies": {
-    "@filecoin-station/spark-evaluate": "^1.0.0",
     "@filecoin-station/spark-impact-evaluator": "^1.2.4",
     "@filecoin-station/spark-stats-db": "^1.0.0",
     "@influxdata/influxdb-client": "^1.35.0",

--- a/observer/package.json
+++ b/observer/package.json
@@ -11,10 +11,10 @@
   },
   "devDependencies": {
     "mocha": "^11.0.1",
-    "spark-evaluate": "github:filecoin-station/spark-evaluate#main",
     "standard": "^17.1.2"
   },
   "dependencies": {
+    "@filecoin-station/spark-evaluate": "^1.0.0",
     "@filecoin-station/spark-impact-evaluator": "^1.2.4",
     "@filecoin-station/spark-stats-db": "^1.0.0",
     "@influxdata/influxdb-client": "^1.35.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,11 @@
       "name": "@filecoin-station/spark-stats-db",
       "version": "1.0.0",
       "dependencies": {
-        "@filecoin-station/spark-evaluate": "^1.0.0",
         "pg": "^8.13.1",
         "postgrator": "^8.0.0"
       },
       "devDependencies": {
+        "@filecoin-station/spark-evaluate": "^1.0.4",
         "standard": "^17.1.2"
       }
     },
@@ -35,6 +35,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.25.9",
@@ -47,6 +48,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.26.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.26.2",
@@ -61,6 +63,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.25.9",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -68,6 +71,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.25.9",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -75,6 +79,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.26.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.26.0"
@@ -88,6 +93,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.25.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.25.9",
@@ -100,6 +106,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.25.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.25.9",
@@ -116,6 +123,7 @@
     },
     "node_modules/@babel/traverse/node_modules/globals": {
       "version": "11.12.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -123,6 +131,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.26.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
@@ -188,9 +197,10 @@
       }
     },
     "node_modules/@filecoin-station/spark-evaluate": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@filecoin-station/spark-evaluate/-/spark-evaluate-1.0.0.tgz",
-      "integrity": "sha512-obkCHMdFqbGUx7yvYe4usv1RQqKcL3hl13i+lF521XtnoVeylEYvjYoBiBnBETxcyP5YpTe4uQlHbdWEGo8m1w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@filecoin-station/spark-evaluate/-/spark-evaluate-1.0.4.tgz",
+      "integrity": "sha512-5KbBALxXJNbWVm2JRHItOnru4Nd2TFztIn1TOQ6VBcsuSp5nCgZAJitNIuB84amoiF3JrAetV1fTePgIoCwuEA==",
+      "dev": true,
       "dependencies": {
         "@filecoin-station/spark-impact-evaluator": "^1.2.4",
         "@glif/filecoin-address": "^3.0.12",
@@ -238,6 +248,7 @@
     },
     "node_modules/@glif/filecoin-address": {
       "version": "3.0.12",
+      "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "blakejs": "1.2.1",
@@ -249,10 +260,12 @@
     },
     "node_modules/@glif/filecoin-address/node_modules/@types/node": {
       "version": "18.15.13",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@glif/filecoin-address/node_modules/ethers": {
       "version": "6.13.2",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -279,6 +292,7 @@
     },
     "node_modules/@glif/filecoin-address/node_modules/tslib": {
       "version": "2.4.0",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -319,6 +333,7 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.4.0.tgz",
       "integrity": "sha512-FiGxOhTUh3fn/kkA+YvNYQjA/T8T5DcKG0NZwAi3aXrizN1qm99HzdYTccEwcX/rUCtI8wTUCKDNPBLUb7pBIQ==",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.7",
@@ -333,6 +348,7 @@
     },
     "node_modules/@ipld/dag-cbor": {
       "version": "9.2.2",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "cborg": "^4.0.0",
@@ -345,6 +361,7 @@
     },
     "node_modules/@ipld/dag-json": {
       "version": "10.2.3",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "cborg": "^4.0.0",
@@ -357,6 +374,7 @@
     },
     "node_modules/@ipld/dag-pb": {
       "version": "4.1.3",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.1.0"
@@ -368,6 +386,7 @@
     },
     "node_modules/@ipld/dag-ucan": {
       "version": "3.4.0",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.0",
@@ -377,6 +396,7 @@
     },
     "node_modules/@ipld/dag-ucan/node_modules/multiformats": {
       "version": "11.0.2",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -387,6 +407,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ipld/unixfs/-/unixfs-2.2.0.tgz",
       "integrity": "sha512-lDQ2eRhJlbFaBoO3bhOmDVCLmpOnhwtwbilqUgAAhbhoPSmLrnv7gsBuToZjXOdPaEGSL7apkmm6nFrcU6zh4Q==",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-pb": "^4.0.0",
@@ -402,6 +423,7 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
       "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0",
@@ -416,12 +438,14 @@
       "version": "13.3.1",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.1.tgz",
       "integrity": "sha512-QxowxTNwJ3r5RMctoGA5p13w5RbRT2QDkoM+yFlqfLiioBp78nhDjnRLvmSBI9+KAqN4VdgOVWM9c0CHd86m3g==",
+      "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@ipld/unixfs/node_modules/multiformats": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
       "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -512,6 +536,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -524,6 +549,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -531,6 +557,7 @@
     },
     "node_modules/@jridgewell/set-array": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -538,10 +565,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -550,6 +579,7 @@
     },
     "node_modules/@multiformats/blake2": {
       "version": "1.0.13",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "blakejs": "^1.1.1",
@@ -558,10 +588,12 @@
     },
     "node_modules/@multiformats/blake2/node_modules/multiformats": {
       "version": "9.9.0",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@multiformats/murmur3": {
       "version": "1.1.3",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "multiformats": "^9.5.4",
@@ -570,10 +602,12 @@
     },
     "node_modules/@multiformats/murmur3/node_modules/multiformats": {
       "version": "9.9.0",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@multiformats/sha3": {
       "version": "2.0.17",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "js-sha3": "^0.8.0",
@@ -582,6 +616,7 @@
     },
     "node_modules/@multiformats/sha3/node_modules/multiformats": {
       "version": "9.9.0",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@noble/curves": {
@@ -596,6 +631,7 @@
     },
     "node_modules/@noble/ed25519": {
       "version": "1.7.3",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1305,6 +1341,7 @@
     },
     "node_modules/@perma/map": {
       "version": "1.0.3",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@multiformats/murmur3": "^2.1.0",
@@ -1313,6 +1350,7 @@
     },
     "node_modules/@perma/map/node_modules/@multiformats/murmur3": {
       "version": "2.1.8",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0",
@@ -1387,22 +1425,27 @@
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
@@ -1411,22 +1454,27 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@rtsao/scc": {
@@ -1436,6 +1484,7 @@
     },
     "node_modules/@scure/base": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1443,6 +1492,7 @@
     },
     "node_modules/@scure/bip39": {
       "version": "1.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "~1.6.0",
@@ -1454,6 +1504,7 @@
     },
     "node_modules/@scure/bip39/node_modules/@noble/hashes": {
       "version": "1.6.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1553,6 +1604,7 @@
     },
     "node_modules/@sovpro/delimited-stream": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1560,6 +1612,7 @@
     },
     "node_modules/@storacha/one-webcrypto": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/connect": {
@@ -1580,6 +1633,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mocha": {
@@ -1623,6 +1677,7 @@
     },
     "node_modules/@types/retry": {
       "version": "0.12.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/shimmer": {
@@ -1644,6 +1699,7 @@
     },
     "node_modules/@ucanto/client": {
       "version": "9.0.1",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ucanto/core": "^10.0.0",
@@ -1654,6 +1710,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-10.2.0.tgz",
       "integrity": "sha512-KlLMg2gx91gnUum1w+zFf33XlcE3WLcSeeeDIKJt1M2zdxAKBmL7RGUtKqx73DxziJqXc31UHjV44ifNUSiLwQ==",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^5.1.0",
@@ -1665,6 +1722,7 @@
     },
     "node_modules/@ucanto/core/node_modules/multiformats": {
       "version": "11.0.2",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -1675,6 +1733,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-10.1.0.tgz",
       "integrity": "sha512-FaWKc24r9Bzi7HCkZbl3mH5WagS7RKoJ8AKb5erPilqyAggOk/yMlAUTLoyF5PmKfe1JO17AWOikWtenLfHjmg==",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/dag-ucan": "^3.4.0",
@@ -1683,6 +1742,7 @@
     },
     "node_modules/@ucanto/interface/node_modules/multiformats": {
       "version": "11.0.2",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -1691,6 +1751,7 @@
     },
     "node_modules/@ucanto/principal": {
       "version": "9.0.1",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/dag-ucan": "^3.4.0",
@@ -1704,6 +1765,7 @@
     },
     "node_modules/@ucanto/principal/node_modules/multiformats": {
       "version": "11.0.2",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -1712,6 +1774,7 @@
     },
     "node_modules/@ucanto/transport": {
       "version": "9.1.1",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ucanto/core": "^10.0.0",
@@ -1720,6 +1783,7 @@
     },
     "node_modules/@ucanto/validator": {
       "version": "9.0.2",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^5.1.0",
@@ -1731,6 +1795,7 @@
     },
     "node_modules/@ucanto/validator/node_modules/multiformats": {
       "version": "11.0.2",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -1744,6 +1809,7 @@
     },
     "node_modules/@web3-storage/access": {
       "version": "20.1.0",
+      "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@ipld/car": "^5.1.1",
@@ -1768,6 +1834,7 @@
     },
     "node_modules/@web3-storage/access/node_modules/multiformats": {
       "version": "12.1.3",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -1776,6 +1843,7 @@
     },
     "node_modules/@web3-storage/access/node_modules/type-fest": {
       "version": "4.29.0",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -1786,6 +1854,7 @@
     },
     "node_modules/@web3-storage/access/node_modules/uint8arrays": {
       "version": "4.0.10",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^12.0.1"
@@ -1795,6 +1864,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@web3-storage/blob-index/-/blob-index-1.0.4.tgz",
       "integrity": "sha512-04+PrmVHFT+xzRhyIPdcvGc8Y2NDffUe8R1gJOyErVzEVz5N1I9Q/BrlFHYt/A4HrjM5JBsxqSrZgTIkjfPmLA==",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.6",
@@ -1814,6 +1884,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
       "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
@@ -1821,6 +1892,7 @@
     },
     "node_modules/@web3-storage/capabilities": {
       "version": "17.4.1",
+      "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@ucanto/core": "^10.0.1",
@@ -1834,6 +1906,7 @@
     },
     "node_modules/@web3-storage/capabilities/node_modules/uint8arrays": {
       "version": "5.1.0",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
@@ -1841,6 +1914,7 @@
     },
     "node_modules/@web3-storage/car-block-validator": {
       "version": "1.2.0",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@multiformats/blake2": "^1.0.13",
@@ -1852,10 +1926,12 @@
     },
     "node_modules/@web3-storage/car-block-validator/node_modules/multiformats": {
       "version": "9.9.0",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@web3-storage/car-block-validator/node_modules/uint8arrays": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "multiformats": "^9.4.2"
@@ -1863,6 +1939,7 @@
     },
     "node_modules/@web3-storage/data-segment": {
       "version": "5.3.0",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/dag-cbor": "^9.2.1",
@@ -1872,6 +1949,7 @@
     },
     "node_modules/@web3-storage/did-mailto": {
       "version": "2.1.0",
+      "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "engines": {
         "node": ">=16.15"
@@ -1881,6 +1959,7 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@web3-storage/filecoin-client/-/filecoin-client-3.3.4.tgz",
       "integrity": "sha512-T2xur1NPvuH09yajyjCWEl7MBH712nqHERj51w4nDp6f8libMCKY6lca0frCrm4OC5s8oy0ZtoRFhsRYxgTzSg==",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-ucan": "^3.4.0",
@@ -1895,6 +1974,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@web3-storage/upload-client/-/upload-client-17.1.2.tgz",
       "integrity": "sha512-rbgPHaqaXKmBA39yk9LAZBIG6wveL3PThgOiR1LI5Mhdo2mKiBacCWua9t6GuUyU2dpZBiTItYWcopcoxN7jwA==",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/car": "^5.2.2",
@@ -1919,12 +1999,14 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@web3-storage/upload-client/node_modules/multiformats": {
       "version": "12.1.3",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
       "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -1935,6 +2017,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
       "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/retry": "0.12.1",
@@ -1951,6 +2034,7 @@
       "version": "16.5.2",
       "resolved": "https://registry.npmjs.org/@web3-storage/w3up-client/-/w3up-client-16.5.2.tgz",
       "integrity": "sha512-yJNh3r2QWZbn2jQ1ZfsnDJ1HIyhv9akEXeFWx+xFxKViT6df8IzT6BtCnxxFL2ED3Tx7rKVVG1pNatKRO3T+Uw==",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-ucan": "^3.4.0",
@@ -1997,6 +2081,7 @@
     },
     "node_modules/actor": {
       "version": "2.3.1",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/aes-js": {
@@ -2020,6 +2105,7 @@
     },
     "node_modules/ajv-formats": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -2035,6 +2121,7 @@
     },
     "node_modules/ajv-formats/node_modules/ajv": {
       "version": "8.17.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2049,6 +2136,7 @@
     },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ansi-colors": {
@@ -2083,6 +2171,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
       "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
@@ -2246,6 +2335,7 @@
     },
     "node_modules/atomically": {
       "version": "2.0.3",
+      "dev": true,
       "dependencies": {
         "stubborn-fs": "^1.2.5",
         "when-exit": "^2.1.1"
@@ -2271,6 +2361,7 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2289,6 +2380,7 @@
     },
     "node_modules/bigint-mod-arith": {
       "version": "3.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.4.0"
@@ -2296,6 +2388,7 @@
     },
     "node_modules/bignumber.js": {
       "version": "9.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -2314,14 +2407,17 @@
     },
     "node_modules/blakejs": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/borc": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0",
@@ -2344,6 +2440,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2365,6 +2462,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
       "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/browser-stdout": {
@@ -2374,6 +2472,7 @@
     },
     "node_modules/buffer": {
       "version": "6.0.3",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2396,6 +2495,7 @@
     },
     "node_modules/buffer-pipe": {
       "version": "0.0.3",
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "safe-buffer": "^5.1.2"
@@ -2461,6 +2561,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/carstream/-/carstream-2.2.0.tgz",
       "integrity": "sha512-/gHkK0lQjmGM45fhdx8JD+x7a1XS1qUk3T9xWWSt3oZiWPLq4u/lnDstp+N55K7hqTKKlb0CCr43EHTrlbmJSQ==",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.3",
@@ -2470,6 +2571,7 @@
     },
     "node_modules/cborg": {
       "version": "4.2.6",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "cborg": "lib/bin.js"
@@ -2554,14 +2656,17 @@
     },
     "node_modules/commander": {
       "version": "2.20.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/conf": {
       "version": "11.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -2582,6 +2687,7 @@
     },
     "node_modules/conf/node_modules/ajv": {
       "version": "8.17.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2596,10 +2702,12 @@
     },
     "node_modules/conf/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/conf/node_modules/semver": {
       "version": "7.6.3",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2670,6 +2778,7 @@
     },
     "node_modules/debounce-fn": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^4.0.0"
@@ -2784,6 +2893,7 @@
     },
     "node_modules/dot-prop": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^2.11.2"
@@ -2797,6 +2907,7 @@
     },
     "node_modules/dot-prop/node_modules/type-fest": {
       "version": "2.19.0",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=12.20"
@@ -2807,6 +2918,7 @@
     },
     "node_modules/drand-client": {
       "version": "1.2.6",
+      "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@babel/traverse": "^7.23.2",
@@ -2819,6 +2931,7 @@
     },
     "node_modules/drand-client/node_modules/@noble/curves": {
       "version": "1.7.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.6.0"
@@ -2832,6 +2945,7 @@
     },
     "node_modules/drand-client/node_modules/@noble/hashes": {
       "version": "1.6.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -2848,6 +2962,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.9.1.tgz",
       "integrity": "sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encoding": "^0.1.13"
@@ -2864,6 +2979,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -2871,6 +2987,7 @@
     },
     "node_modules/env-paths": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -2883,6 +3000,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
       "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/error-ex": {
@@ -3553,16 +3671,19 @@
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3577,6 +3698,7 @@
     },
     "node_modules/fast-uri": {
       "version": "3.0.3",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
@@ -3600,6 +3722,7 @@
     },
     "node_modules/files-from-path": {
       "version": "1.1.1",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "graceful-fs": "^4.2.10"
@@ -3767,6 +3890,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
       "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/get-stdin": {
@@ -3868,6 +3992,7 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -3877,6 +4002,7 @@
     },
     "node_modules/hamt-sharding": {
       "version": "3.0.6",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "sparse-array": "^1.3.1",
@@ -3885,6 +4011,7 @@
     },
     "node_modules/hamt-sharding/node_modules/uint8arrays": {
       "version": "5.1.0",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
@@ -4004,6 +4131,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4014,6 +4142,7 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4086,6 +4215,7 @@
     },
     "node_modules/interface-blockstore": {
       "version": "5.3.1",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "interface-store": "^6.0.0",
@@ -4094,6 +4224,7 @@
     },
     "node_modules/interface-store": {
       "version": "6.0.2",
+      "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/internal-slot": {
@@ -4111,6 +4242,7 @@
     },
     "node_modules/ipfs-car": {
       "version": "1.2.0",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/car": "^5.1.0",
@@ -4135,6 +4267,7 @@
     },
     "node_modules/ipfs-car/node_modules/@ipld/unixfs": {
       "version": "3.0.0",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-pb": "^4.0.0",
@@ -4148,6 +4281,7 @@
     },
     "node_modules/ipfs-car/node_modules/@multiformats/murmur3": {
       "version": "2.1.8",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0",
@@ -4160,6 +4294,7 @@
     },
     "node_modules/ipfs-unixfs": {
       "version": "11.2.0",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "protons-runtime": "^5.5.0",
@@ -4168,6 +4303,7 @@
     },
     "node_modules/ipfs-unixfs-exporter": {
       "version": "13.6.1",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.2.1",
@@ -4190,6 +4326,7 @@
     },
     "node_modules/ipfs-unixfs-exporter/node_modules/@multiformats/murmur3": {
       "version": "2.1.8",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0",
@@ -4204,6 +4341,7 @@
       "version": "9.0.14",
       "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.14.tgz",
       "integrity": "sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "any-signal": "^3.0.0",
@@ -4355,6 +4493,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
       "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-extglob": {
@@ -4435,6 +4574,7 @@
     },
     "node_modules/is-network-error": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -4475,6 +4615,7 @@
     },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4621,6 +4762,7 @@
     },
     "node_modules/iso-url": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4630,10 +4772,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
       "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/it-filter": {
       "version": "3.1.1",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-peekable": "^3.0.0"
@@ -4643,6 +4787,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
       "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@types/minimatch": "^3.0.4",
@@ -4651,10 +4796,12 @@
     },
     "node_modules/it-last": {
       "version": "3.0.6",
+      "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-map": {
       "version": "3.1.1",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-peekable": "^3.0.0"
@@ -4662,6 +4809,7 @@
     },
     "node_modules/it-merge": {
       "version": "3.0.5",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-pushable": "^3.2.3"
@@ -4669,6 +4817,7 @@
     },
     "node_modules/it-parallel": {
       "version": "3.0.8",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "p-defer": "^4.0.1"
@@ -4676,10 +4825,12 @@
     },
     "node_modules/it-peekable": {
       "version": "3.0.5",
+      "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-pipe": {
       "version": "3.0.1",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-merge": "^3.0.0",
@@ -4693,6 +4844,7 @@
     },
     "node_modules/it-pushable": {
       "version": "3.2.3",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "p-defer": "^4.0.0"
@@ -4700,12 +4852,14 @@
     },
     "node_modules/it-stream-types": {
       "version": "2.0.2",
+      "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-to-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
       "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
@@ -4720,6 +4874,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
       "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4755,10 +4910,12 @@
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4774,6 +4931,7 @@
     },
     "node_modules/jsesc": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -4799,6 +4957,7 @@
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.1",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -4808,6 +4967,7 @@
     },
     "node_modules/json-text-sequence": {
       "version": "0.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sovpro/delimited-stream": "^1.1.0"
@@ -4843,10 +5003,12 @@
     },
     "node_modules/just-percentile": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/k-closest": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/keyv": {
@@ -4859,6 +5021,7 @@
     },
     "node_modules/leb128": {
       "version": "0.0.5",
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^5.0.0",
@@ -4936,6 +5099,7 @@
     },
     "node_modules/long": {
       "version": "5.2.3",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
@@ -4960,6 +5124,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
       "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-plain-obj": "^2.1.0"
@@ -4970,6 +5135,7 @@
     },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4980,6 +5146,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -5159,6 +5326,7 @@
     },
     "node_modules/mri": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -5170,10 +5338,12 @@
     },
     "node_modules/multiformats": {
       "version": "13.3.1",
+      "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -5183,6 +5353,7 @@
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
       "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5201,6 +5372,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
       "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "node-fetch": "*"
@@ -5235,6 +5407,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -5376,6 +5549,7 @@
     },
     "node_modules/one-webcrypto": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -5396,6 +5570,7 @@
     },
     "node_modules/p-defer": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5408,6 +5583,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
       "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-fifo": "^1.0.0",
@@ -5418,6 +5594,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
       "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5455,6 +5632,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
       "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5465,6 +5643,7 @@
     },
     "node_modules/p-queue": {
       "version": "8.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1",
@@ -5479,6 +5658,7 @@
     },
     "node_modules/p-retry": {
       "version": "6.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/retry": "0.12.2",
@@ -5494,6 +5674,7 @@
     },
     "node_modules/p-timeout": {
       "version": "6.1.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -5707,6 +5888,7 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -5900,6 +6082,7 @@
     },
     "node_modules/progress-events": {
       "version": "1.0.1",
+      "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/prop-types": {
@@ -5914,6 +6097,7 @@
     },
     "node_modules/protobufjs": {
       "version": "7.4.0",
+      "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5936,6 +6120,7 @@
     },
     "node_modules/protons-runtime": {
       "version": "5.5.0",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "uint8-varint": "^2.0.2",
@@ -5945,6 +6130,7 @@
     },
     "node_modules/protons-runtime/node_modules/uint8arrays": {
       "version": "5.1.0",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
@@ -5979,6 +6165,7 @@
     },
     "node_modules/rabin-rs": {
       "version": "2.1.0",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/randombytes": {
@@ -5998,6 +6185,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
       "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-defer": "^3.0.0"
@@ -6007,6 +6195,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
       "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6014,6 +6203,7 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -6093,6 +6283,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6135,6 +6326,7 @@
     },
     "node_modules/retry": {
       "version": "0.13.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -6187,6 +6379,7 @@
     },
     "node_modules/sade": {
       "version": "1.8.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mri": "^1.1.0"
@@ -6214,6 +6407,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6250,6 +6444,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -6359,6 +6554,7 @@
     },
     "node_modules/sparse-array": {
       "version": "1.3.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/split2": {
@@ -6443,6 +6639,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
       "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-iterator": "^1.0.2"
@@ -6450,6 +6647,7 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -6601,7 +6799,8 @@
       }
     },
     "node_modules/stubborn-fs": {
-      "version": "1.2.5"
+      "version": "1.2.5",
+      "dev": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -6626,6 +6825,7 @@
     },
     "node_modules/sync-multihash-sha2": {
       "version": "1.0.0",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@noble/hashes": "^1.3.1"
@@ -6658,6 +6858,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
@@ -6782,6 +6983,7 @@
     },
     "node_modules/uint8-varint": {
       "version": "2.0.4",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "uint8arraylist": "^2.0.0",
@@ -6790,6 +6992,7 @@
     },
     "node_modules/uint8-varint/node_modules/uint8arrays": {
       "version": "5.1.0",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
@@ -6797,6 +7000,7 @@
     },
     "node_modules/uint8arraylist": {
       "version": "2.4.8",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "uint8arrays": "^5.0.1"
@@ -6804,6 +7008,7 @@
     },
     "node_modules/uint8arraylist/node_modules/uint8arrays": {
       "version": "5.1.0",
+      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
@@ -6811,6 +7016,7 @@
     },
     "node_modules/uint8arrays": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "multiformats": "^9.4.2"
@@ -6818,6 +7024,7 @@
     },
     "node_modules/uint8arrays/node_modules/multiformats": {
       "version": "9.9.0",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/unbox-primitive": {
@@ -6848,10 +7055,12 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/varint": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/version-guard": {
@@ -6866,12 +7075,14 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -6879,7 +7090,8 @@
       }
     },
     "node_modules/when-exit": {
-      "version": "2.1.3"
+      "version": "2.1.3",
+      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -7115,7 +7327,6 @@
     "observer": {
       "name": "@filecoin-station/spark-observer",
       "dependencies": {
-        "@filecoin-station/spark-evaluate": "^1.0.0",
         "@filecoin-station/spark-impact-evaluator": "^1.2.4",
         "@filecoin-station/spark-stats-db": "^1.0.0",
         "@influxdata/influxdb-client": "^1.35.0",
@@ -7127,6 +7338,7 @@
         "slug": "^10.0.0"
       },
       "devDependencies": {
+        "@filecoin-station/spark-evaluate": "^1.0.4",
         "mocha": "^11.0.1",
         "standard": "^17.1.2"
       }
@@ -7134,7 +7346,6 @@
     "stats": {
       "name": "@filecoin-station/spark-stats",
       "dependencies": {
-        "@filecoin-station/spark-evaluate": "^1.0.0",
         "@filecoin-station/spark-stats-db": "^1.0.0",
         "@sentry/node": "^8.48.0",
         "@sentry/profiling-node": "^8.50.0",
@@ -7144,6 +7355,7 @@
         "pg": "^8.13.1"
       },
       "devDependencies": {
+        "@filecoin-station/spark-evaluate": "^1.0.4",
         "@filecoin-station/spark-stats-db": "^1.0.0",
         "mocha": "^11.0.1",
         "standard": "^17.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,40 +21,12 @@
       "name": "@filecoin-station/spark-stats-db",
       "version": "1.0.0",
       "dependencies": {
+        "@filecoin-station/spark-evaluate": "^1.0.0",
         "pg": "^8.13.1",
-        "postgrator": "^8.0.0",
-        "spark-evaluate": "filecoin-station/spark-evaluate#main"
+        "postgrator": "^8.0.0"
       },
       "devDependencies": {
         "standard": "^17.1.2"
-      }
-    },
-    "db/node_modules/spark-evaluate": {
-      "resolved": "git+ssh://git@github.com/filecoin-station/spark-evaluate.git#d2368132e8c8987c87cb5700dc13dfeda291cd17",
-      "dependencies": {
-        "@filecoin-station/spark-impact-evaluator": "^1.2.4",
-        "@glif/filecoin-address": "^3.0.12",
-        "@influxdata/influxdb-client": "^1.35.0",
-        "@ipld/car": "^5.3.3",
-        "@ipld/dag-json": "^10.2.3",
-        "@sentry/node": "^8.42.0",
-        "@ucanto/core": "^10.0.1",
-        "@ucanto/principal": "^9.0.1",
-        "@web3-storage/car-block-validator": "^1.2.0",
-        "@web3-storage/w3up-client": "^16.5.2",
-        "debug": "^4.3.7",
-        "drand-client": "^1.2.6",
-        "ethers": "^6.13.4",
-        "ipfs-car": "^1.2.0",
-        "ipfs-unixfs-exporter": "^13.6.1",
-        "just-percentile": "^4.2.0",
-        "k-closest": "^1.3.0",
-        "ms": "^2.1.3",
-        "multiformats": "^13.3.1",
-        "p-map": "^7.0.2",
-        "p-retry": "^6.2.1",
-        "pg": "^8.13.1",
-        "postgrator": "^8.0.0"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -215,6 +187,36 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@filecoin-station/spark-evaluate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@filecoin-station/spark-evaluate/-/spark-evaluate-1.0.0.tgz",
+      "integrity": "sha512-obkCHMdFqbGUx7yvYe4usv1RQqKcL3hl13i+lF521XtnoVeylEYvjYoBiBnBETxcyP5YpTe4uQlHbdWEGo8m1w==",
+      "dependencies": {
+        "@filecoin-station/spark-impact-evaluator": "^1.2.4",
+        "@glif/filecoin-address": "^3.0.12",
+        "@influxdata/influxdb-client": "^1.35.0",
+        "@ipld/car": "^5.4.0",
+        "@ipld/dag-json": "^10.2.3",
+        "@sentry/node": "^8.50.0",
+        "@ucanto/core": "^10.2.0",
+        "@ucanto/principal": "^9.0.1",
+        "@web3-storage/car-block-validator": "^1.2.0",
+        "@web3-storage/w3up-client": "^16.5.2",
+        "debug": "^4.4.0",
+        "drand-client": "^1.2.6",
+        "ethers": "^6.13.5",
+        "ipfs-car": "^1.2.0",
+        "ipfs-unixfs-exporter": "^13.6.1",
+        "just-percentile": "^4.2.0",
+        "k-closest": "^1.3.0",
+        "ms": "^2.1.3",
+        "multiformats": "^13.3.1",
+        "p-map": "^7.0.3",
+        "p-retry": "^6.2.1",
+        "pg": "^8.13.1",
+        "postgrator": "^8.0.0"
+      }
+    },
     "node_modules/@filecoin-station/spark-impact-evaluator": {
       "version": "1.2.4",
       "license": "(Apache-2.0 AND MIT)",
@@ -314,7 +316,9 @@
       "license": "MIT"
     },
     "node_modules/@ipld/car": {
-      "version": "5.3.3",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.4.0.tgz",
+      "integrity": "sha512-FiGxOhTUh3fn/kkA+YvNYQjA/T8T5DcKG0NZwAi3aXrizN1qm99HzdYTccEwcX/rUCtI8wTUCKDNPBLUb7pBIQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.7",
@@ -1647,13 +1651,15 @@
       }
     },
     "node_modules/@ucanto/core": {
-      "version": "10.0.1",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-10.2.0.tgz",
+      "integrity": "sha512-KlLMg2gx91gnUum1w+zFf33XlcE3WLcSeeeDIKJt1M2zdxAKBmL7RGUtKqx73DxziJqXc31UHjV44ifNUSiLwQ==",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^5.1.0",
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-ucan": "^3.4.0",
-        "@ucanto/interface": "^10.0.1",
+        "@ucanto/interface": "^10.1.0",
         "multiformats": "^11.0.2"
       }
     },
@@ -1666,7 +1672,9 @@
       }
     },
     "node_modules/@ucanto/interface": {
-      "version": "10.0.1",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-10.1.0.tgz",
+      "integrity": "sha512-FaWKc24r9Bzi7HCkZbl3mH5WagS7RKoJ8AKb5erPilqyAggOk/yMlAUTLoyF5PmKfe1JO17AWOikWtenLfHjmg==",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/dag-ucan": "^3.4.0",
@@ -5444,7 +5452,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.2",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7105,6 +7115,7 @@
     "observer": {
       "name": "@filecoin-station/spark-observer",
       "dependencies": {
+        "@filecoin-station/spark-evaluate": "^1.0.0",
         "@filecoin-station/spark-impact-evaluator": "^1.2.4",
         "@filecoin-station/spark-stats-db": "^1.0.0",
         "@influxdata/influxdb-client": "^1.35.0",
@@ -7117,42 +7128,13 @@
       },
       "devDependencies": {
         "mocha": "^11.0.1",
-        "spark-evaluate": "github:filecoin-station/spark-evaluate#main",
         "standard": "^17.1.2"
-      }
-    },
-    "observer/node_modules/spark-evaluate": {
-      "resolved": "git+ssh://git@github.com/filecoin-station/spark-evaluate.git#d2368132e8c8987c87cb5700dc13dfeda291cd17",
-      "dev": true,
-      "dependencies": {
-        "@filecoin-station/spark-impact-evaluator": "^1.2.4",
-        "@glif/filecoin-address": "^3.0.12",
-        "@influxdata/influxdb-client": "^1.35.0",
-        "@ipld/car": "^5.3.3",
-        "@ipld/dag-json": "^10.2.3",
-        "@sentry/node": "^8.42.0",
-        "@ucanto/core": "^10.0.1",
-        "@ucanto/principal": "^9.0.1",
-        "@web3-storage/car-block-validator": "^1.2.0",
-        "@web3-storage/w3up-client": "^16.5.2",
-        "debug": "^4.3.7",
-        "drand-client": "^1.2.6",
-        "ethers": "^6.13.4",
-        "ipfs-car": "^1.2.0",
-        "ipfs-unixfs-exporter": "^13.6.1",
-        "just-percentile": "^4.2.0",
-        "k-closest": "^1.3.0",
-        "ms": "^2.1.3",
-        "multiformats": "^13.3.1",
-        "p-map": "^7.0.2",
-        "p-retry": "^6.2.1",
-        "pg": "^8.13.1",
-        "postgrator": "^8.0.0"
       }
     },
     "stats": {
       "name": "@filecoin-station/spark-stats",
       "dependencies": {
+        "@filecoin-station/spark-evaluate": "^1.0.0",
         "@filecoin-station/spark-stats-db": "^1.0.0",
         "@sentry/node": "^8.48.0",
         "@sentry/profiling-node": "^8.50.0",
@@ -7164,37 +7146,7 @@
       "devDependencies": {
         "@filecoin-station/spark-stats-db": "^1.0.0",
         "mocha": "^11.0.1",
-        "spark-evaluate": "filecoin-station/spark-evaluate#main",
         "standard": "^17.1.2"
-      }
-    },
-    "stats/node_modules/spark-evaluate": {
-      "resolved": "git+ssh://git@github.com/filecoin-station/spark-evaluate.git#d2368132e8c8987c87cb5700dc13dfeda291cd17",
-      "dev": true,
-      "dependencies": {
-        "@filecoin-station/spark-impact-evaluator": "^1.2.4",
-        "@glif/filecoin-address": "^3.0.12",
-        "@influxdata/influxdb-client": "^1.35.0",
-        "@ipld/car": "^5.3.3",
-        "@ipld/dag-json": "^10.2.3",
-        "@sentry/node": "^8.42.0",
-        "@ucanto/core": "^10.0.1",
-        "@ucanto/principal": "^9.0.1",
-        "@web3-storage/car-block-validator": "^1.2.0",
-        "@web3-storage/w3up-client": "^16.5.2",
-        "debug": "^4.3.7",
-        "drand-client": "^1.2.6",
-        "ethers": "^6.13.4",
-        "ipfs-car": "^1.2.0",
-        "ipfs-unixfs-exporter": "^13.6.1",
-        "just-percentile": "^4.2.0",
-        "k-closest": "^1.3.0",
-        "ms": "^2.1.3",
-        "multiformats": "^13.3.1",
-        "p-map": "^7.0.2",
-        "p-retry": "^6.2.1",
-        "pg": "^8.13.1",
-        "postgrator": "^8.0.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,11 @@
       "name": "@filecoin-station/spark-stats-db",
       "version": "1.0.0",
       "dependencies": {
+        "@filecoin-station/spark-evaluate": "^1.0.4",
         "pg": "^8.13.1",
         "postgrator": "^8.0.0"
       },
       "devDependencies": {
-        "@filecoin-station/spark-evaluate": "^1.0.4",
         "standard": "^17.1.2"
       }
     },
@@ -35,7 +35,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.25.9",
@@ -48,7 +47,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.26.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.26.2",
@@ -63,7 +61,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.25.9",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -71,7 +68,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.25.9",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -79,7 +75,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.26.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.26.0"
@@ -93,7 +88,6 @@
     },
     "node_modules/@babel/template": {
       "version": "7.25.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.25.9",
@@ -106,7 +100,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.25.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.25.9",
@@ -123,7 +116,6 @@
     },
     "node_modules/@babel/traverse/node_modules/globals": {
       "version": "11.12.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -131,7 +123,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.26.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
@@ -200,7 +191,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@filecoin-station/spark-evaluate/-/spark-evaluate-1.0.4.tgz",
       "integrity": "sha512-5KbBALxXJNbWVm2JRHItOnru4Nd2TFztIn1TOQ6VBcsuSp5nCgZAJitNIuB84amoiF3JrAetV1fTePgIoCwuEA==",
-      "dev": true,
       "dependencies": {
         "@filecoin-station/spark-impact-evaluator": "^1.2.4",
         "@glif/filecoin-address": "^3.0.12",
@@ -248,7 +238,6 @@
     },
     "node_modules/@glif/filecoin-address": {
       "version": "3.0.12",
-      "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "blakejs": "1.2.1",
@@ -260,12 +249,10 @@
     },
     "node_modules/@glif/filecoin-address/node_modules/@types/node": {
       "version": "18.15.13",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@glif/filecoin-address/node_modules/ethers": {
       "version": "6.13.2",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -292,7 +279,6 @@
     },
     "node_modules/@glif/filecoin-address/node_modules/tslib": {
       "version": "2.4.0",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -333,7 +319,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.4.0.tgz",
       "integrity": "sha512-FiGxOhTUh3fn/kkA+YvNYQjA/T8T5DcKG0NZwAi3aXrizN1qm99HzdYTccEwcX/rUCtI8wTUCKDNPBLUb7pBIQ==",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.7",
@@ -348,7 +333,6 @@
     },
     "node_modules/@ipld/dag-cbor": {
       "version": "9.2.2",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "cborg": "^4.0.0",
@@ -361,7 +345,6 @@
     },
     "node_modules/@ipld/dag-json": {
       "version": "10.2.3",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "cborg": "^4.0.0",
@@ -374,7 +357,6 @@
     },
     "node_modules/@ipld/dag-pb": {
       "version": "4.1.3",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.1.0"
@@ -386,7 +368,6 @@
     },
     "node_modules/@ipld/dag-ucan": {
       "version": "3.4.0",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.0",
@@ -396,7 +377,6 @@
     },
     "node_modules/@ipld/dag-ucan/node_modules/multiformats": {
       "version": "11.0.2",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -407,7 +387,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ipld/unixfs/-/unixfs-2.2.0.tgz",
       "integrity": "sha512-lDQ2eRhJlbFaBoO3bhOmDVCLmpOnhwtwbilqUgAAhbhoPSmLrnv7gsBuToZjXOdPaEGSL7apkmm6nFrcU6zh4Q==",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-pb": "^4.0.0",
@@ -423,7 +402,6 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
       "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0",
@@ -438,14 +416,12 @@
       "version": "13.3.1",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.1.tgz",
       "integrity": "sha512-QxowxTNwJ3r5RMctoGA5p13w5RbRT2QDkoM+yFlqfLiioBp78nhDjnRLvmSBI9+KAqN4VdgOVWM9c0CHd86m3g==",
-      "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@ipld/unixfs/node_modules/multiformats": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
       "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -536,7 +512,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -549,7 +524,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -557,7 +531,6 @@
     },
     "node_modules/@jridgewell/set-array": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -565,12 +538,10 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -579,7 +550,6 @@
     },
     "node_modules/@multiformats/blake2": {
       "version": "1.0.13",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "blakejs": "^1.1.1",
@@ -588,12 +558,10 @@
     },
     "node_modules/@multiformats/blake2/node_modules/multiformats": {
       "version": "9.9.0",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@multiformats/murmur3": {
       "version": "1.1.3",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "multiformats": "^9.5.4",
@@ -602,12 +570,10 @@
     },
     "node_modules/@multiformats/murmur3/node_modules/multiformats": {
       "version": "9.9.0",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@multiformats/sha3": {
       "version": "2.0.17",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "js-sha3": "^0.8.0",
@@ -616,7 +582,6 @@
     },
     "node_modules/@multiformats/sha3/node_modules/multiformats": {
       "version": "9.9.0",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@noble/curves": {
@@ -631,7 +596,6 @@
     },
     "node_modules/@noble/ed25519": {
       "version": "1.7.3",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1341,7 +1305,6 @@
     },
     "node_modules/@perma/map": {
       "version": "1.0.3",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@multiformats/murmur3": "^2.1.0",
@@ -1350,7 +1313,6 @@
     },
     "node_modules/@perma/map/node_modules/@multiformats/murmur3": {
       "version": "2.1.8",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0",
@@ -1425,27 +1387,22 @@
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
@@ -1454,27 +1411,22 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@rtsao/scc": {
@@ -1484,7 +1436,6 @@
     },
     "node_modules/@scure/base": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1492,7 +1443,6 @@
     },
     "node_modules/@scure/bip39": {
       "version": "1.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "~1.6.0",
@@ -1504,7 +1454,6 @@
     },
     "node_modules/@scure/bip39/node_modules/@noble/hashes": {
       "version": "1.6.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1604,7 +1553,6 @@
     },
     "node_modules/@sovpro/delimited-stream": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1612,7 +1560,6 @@
     },
     "node_modules/@storacha/one-webcrypto": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/connect": {
@@ -1633,7 +1580,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mocha": {
@@ -1677,7 +1623,6 @@
     },
     "node_modules/@types/retry": {
       "version": "0.12.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/shimmer": {
@@ -1699,7 +1644,6 @@
     },
     "node_modules/@ucanto/client": {
       "version": "9.0.1",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ucanto/core": "^10.0.0",
@@ -1710,7 +1654,6 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-10.2.0.tgz",
       "integrity": "sha512-KlLMg2gx91gnUum1w+zFf33XlcE3WLcSeeeDIKJt1M2zdxAKBmL7RGUtKqx73DxziJqXc31UHjV44ifNUSiLwQ==",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^5.1.0",
@@ -1722,7 +1665,6 @@
     },
     "node_modules/@ucanto/core/node_modules/multiformats": {
       "version": "11.0.2",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -1733,7 +1675,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-10.1.0.tgz",
       "integrity": "sha512-FaWKc24r9Bzi7HCkZbl3mH5WagS7RKoJ8AKb5erPilqyAggOk/yMlAUTLoyF5PmKfe1JO17AWOikWtenLfHjmg==",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/dag-ucan": "^3.4.0",
@@ -1742,7 +1683,6 @@
     },
     "node_modules/@ucanto/interface/node_modules/multiformats": {
       "version": "11.0.2",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -1751,7 +1691,6 @@
     },
     "node_modules/@ucanto/principal": {
       "version": "9.0.1",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/dag-ucan": "^3.4.0",
@@ -1765,7 +1704,6 @@
     },
     "node_modules/@ucanto/principal/node_modules/multiformats": {
       "version": "11.0.2",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -1774,7 +1712,6 @@
     },
     "node_modules/@ucanto/transport": {
       "version": "9.1.1",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ucanto/core": "^10.0.0",
@@ -1783,7 +1720,6 @@
     },
     "node_modules/@ucanto/validator": {
       "version": "9.0.2",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^5.1.0",
@@ -1795,7 +1731,6 @@
     },
     "node_modules/@ucanto/validator/node_modules/multiformats": {
       "version": "11.0.2",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -1809,7 +1744,6 @@
     },
     "node_modules/@web3-storage/access": {
       "version": "20.1.0",
-      "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@ipld/car": "^5.1.1",
@@ -1834,7 +1768,6 @@
     },
     "node_modules/@web3-storage/access/node_modules/multiformats": {
       "version": "12.1.3",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -1843,7 +1776,6 @@
     },
     "node_modules/@web3-storage/access/node_modules/type-fest": {
       "version": "4.29.0",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -1854,7 +1786,6 @@
     },
     "node_modules/@web3-storage/access/node_modules/uint8arrays": {
       "version": "4.0.10",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^12.0.1"
@@ -1864,7 +1795,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@web3-storage/blob-index/-/blob-index-1.0.4.tgz",
       "integrity": "sha512-04+PrmVHFT+xzRhyIPdcvGc8Y2NDffUe8R1gJOyErVzEVz5N1I9Q/BrlFHYt/A4HrjM5JBsxqSrZgTIkjfPmLA==",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.6",
@@ -1884,7 +1814,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
       "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
@@ -1892,7 +1821,6 @@
     },
     "node_modules/@web3-storage/capabilities": {
       "version": "17.4.1",
-      "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@ucanto/core": "^10.0.1",
@@ -1906,7 +1834,6 @@
     },
     "node_modules/@web3-storage/capabilities/node_modules/uint8arrays": {
       "version": "5.1.0",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
@@ -1914,7 +1841,6 @@
     },
     "node_modules/@web3-storage/car-block-validator": {
       "version": "1.2.0",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@multiformats/blake2": "^1.0.13",
@@ -1926,12 +1852,10 @@
     },
     "node_modules/@web3-storage/car-block-validator/node_modules/multiformats": {
       "version": "9.9.0",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@web3-storage/car-block-validator/node_modules/uint8arrays": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "multiformats": "^9.4.2"
@@ -1939,7 +1863,6 @@
     },
     "node_modules/@web3-storage/data-segment": {
       "version": "5.3.0",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/dag-cbor": "^9.2.1",
@@ -1949,7 +1872,6 @@
     },
     "node_modules/@web3-storage/did-mailto": {
       "version": "2.1.0",
-      "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "engines": {
         "node": ">=16.15"
@@ -1959,7 +1881,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@web3-storage/filecoin-client/-/filecoin-client-3.3.4.tgz",
       "integrity": "sha512-T2xur1NPvuH09yajyjCWEl7MBH712nqHERj51w4nDp6f8libMCKY6lca0frCrm4OC5s8oy0ZtoRFhsRYxgTzSg==",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-ucan": "^3.4.0",
@@ -1974,7 +1895,6 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@web3-storage/upload-client/-/upload-client-17.1.2.tgz",
       "integrity": "sha512-rbgPHaqaXKmBA39yk9LAZBIG6wveL3PThgOiR1LI5Mhdo2mKiBacCWua9t6GuUyU2dpZBiTItYWcopcoxN7jwA==",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/car": "^5.2.2",
@@ -1999,14 +1919,12 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@web3-storage/upload-client/node_modules/multiformats": {
       "version": "12.1.3",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
       "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -2017,7 +1935,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
       "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/retry": "0.12.1",
@@ -2034,7 +1951,6 @@
       "version": "16.5.2",
       "resolved": "https://registry.npmjs.org/@web3-storage/w3up-client/-/w3up-client-16.5.2.tgz",
       "integrity": "sha512-yJNh3r2QWZbn2jQ1ZfsnDJ1HIyhv9akEXeFWx+xFxKViT6df8IzT6BtCnxxFL2ED3Tx7rKVVG1pNatKRO3T+Uw==",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-ucan": "^3.4.0",
@@ -2081,7 +1997,6 @@
     },
     "node_modules/actor": {
       "version": "2.3.1",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/aes-js": {
@@ -2105,7 +2020,6 @@
     },
     "node_modules/ajv-formats": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -2121,7 +2035,6 @@
     },
     "node_modules/ajv-formats/node_modules/ajv": {
       "version": "8.17.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2136,7 +2049,6 @@
     },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ansi-colors": {
@@ -2171,7 +2083,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
       "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
@@ -2335,7 +2246,6 @@
     },
     "node_modules/atomically": {
       "version": "2.0.3",
-      "dev": true,
       "dependencies": {
         "stubborn-fs": "^1.2.5",
         "when-exit": "^2.1.1"
@@ -2361,7 +2271,6 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2380,7 +2289,6 @@
     },
     "node_modules/bigint-mod-arith": {
       "version": "3.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.4.0"
@@ -2388,7 +2296,6 @@
     },
     "node_modules/bignumber.js": {
       "version": "9.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -2407,17 +2314,14 @@
     },
     "node_modules/blakejs": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/borc": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0",
@@ -2440,7 +2344,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2462,7 +2365,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
       "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/browser-stdout": {
@@ -2472,7 +2374,6 @@
     },
     "node_modules/buffer": {
       "version": "6.0.3",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2495,7 +2396,6 @@
     },
     "node_modules/buffer-pipe": {
       "version": "0.0.3",
-      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "safe-buffer": "^5.1.2"
@@ -2561,7 +2461,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/carstream/-/carstream-2.2.0.tgz",
       "integrity": "sha512-/gHkK0lQjmGM45fhdx8JD+x7a1XS1qUk3T9xWWSt3oZiWPLq4u/lnDstp+N55K7hqTKKlb0CCr43EHTrlbmJSQ==",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.3",
@@ -2571,7 +2470,6 @@
     },
     "node_modules/cborg": {
       "version": "4.2.6",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "cborg": "lib/bin.js"
@@ -2656,17 +2554,14 @@
     },
     "node_modules/commander": {
       "version": "2.20.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/conf": {
       "version": "11.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -2687,7 +2582,6 @@
     },
     "node_modules/conf/node_modules/ajv": {
       "version": "8.17.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2702,12 +2596,10 @@
     },
     "node_modules/conf/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/conf/node_modules/semver": {
       "version": "7.6.3",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2778,7 +2670,6 @@
     },
     "node_modules/debounce-fn": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^4.0.0"
@@ -2893,7 +2784,6 @@
     },
     "node_modules/dot-prop": {
       "version": "7.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^2.11.2"
@@ -2907,7 +2797,6 @@
     },
     "node_modules/dot-prop/node_modules/type-fest": {
       "version": "2.19.0",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=12.20"
@@ -2918,7 +2807,6 @@
     },
     "node_modules/drand-client": {
       "version": "1.2.6",
-      "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@babel/traverse": "^7.23.2",
@@ -2931,7 +2819,6 @@
     },
     "node_modules/drand-client/node_modules/@noble/curves": {
       "version": "1.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.6.0"
@@ -2945,7 +2832,6 @@
     },
     "node_modules/drand-client/node_modules/@noble/hashes": {
       "version": "1.6.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -2962,7 +2848,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.9.1.tgz",
       "integrity": "sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encoding": "^0.1.13"
@@ -2979,7 +2864,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -2987,7 +2871,6 @@
     },
     "node_modules/env-paths": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -3000,7 +2883,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
       "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/error-ex": {
@@ -3671,19 +3553,16 @@
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3698,7 +3577,6 @@
     },
     "node_modules/fast-uri": {
       "version": "3.0.3",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
@@ -3722,7 +3600,6 @@
     },
     "node_modules/files-from-path": {
       "version": "1.1.1",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "graceful-fs": "^4.2.10"
@@ -3890,7 +3767,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
       "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/get-stdin": {
@@ -3992,7 +3868,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -4002,7 +3877,6 @@
     },
     "node_modules/hamt-sharding": {
       "version": "3.0.6",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "sparse-array": "^1.3.1",
@@ -4011,7 +3885,6 @@
     },
     "node_modules/hamt-sharding/node_modules/uint8arrays": {
       "version": "5.1.0",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
@@ -4131,7 +4004,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4142,7 +4014,6 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4215,7 +4086,6 @@
     },
     "node_modules/interface-blockstore": {
       "version": "5.3.1",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "interface-store": "^6.0.0",
@@ -4224,7 +4094,6 @@
     },
     "node_modules/interface-store": {
       "version": "6.0.2",
-      "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/internal-slot": {
@@ -4242,7 +4111,6 @@
     },
     "node_modules/ipfs-car": {
       "version": "1.2.0",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/car": "^5.1.0",
@@ -4267,7 +4135,6 @@
     },
     "node_modules/ipfs-car/node_modules/@ipld/unixfs": {
       "version": "3.0.0",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-pb": "^4.0.0",
@@ -4281,7 +4148,6 @@
     },
     "node_modules/ipfs-car/node_modules/@multiformats/murmur3": {
       "version": "2.1.8",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0",
@@ -4294,7 +4160,6 @@
     },
     "node_modules/ipfs-unixfs": {
       "version": "11.2.0",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "protons-runtime": "^5.5.0",
@@ -4303,7 +4168,6 @@
     },
     "node_modules/ipfs-unixfs-exporter": {
       "version": "13.6.1",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.2.1",
@@ -4326,7 +4190,6 @@
     },
     "node_modules/ipfs-unixfs-exporter/node_modules/@multiformats/murmur3": {
       "version": "2.1.8",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0",
@@ -4341,7 +4204,6 @@
       "version": "9.0.14",
       "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.14.tgz",
       "integrity": "sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "any-signal": "^3.0.0",
@@ -4493,7 +4355,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
       "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-extglob": {
@@ -4574,7 +4435,6 @@
     },
     "node_modules/is-network-error": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -4615,7 +4475,6 @@
     },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4762,7 +4621,6 @@
     },
     "node_modules/iso-url": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4772,12 +4630,10 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
       "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/it-filter": {
       "version": "3.1.1",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-peekable": "^3.0.0"
@@ -4787,7 +4643,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
       "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@types/minimatch": "^3.0.4",
@@ -4796,12 +4651,10 @@
     },
     "node_modules/it-last": {
       "version": "3.0.6",
-      "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-map": {
       "version": "3.1.1",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-peekable": "^3.0.0"
@@ -4809,7 +4662,6 @@
     },
     "node_modules/it-merge": {
       "version": "3.0.5",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-pushable": "^3.2.3"
@@ -4817,7 +4669,6 @@
     },
     "node_modules/it-parallel": {
       "version": "3.0.8",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "p-defer": "^4.0.1"
@@ -4825,12 +4676,10 @@
     },
     "node_modules/it-peekable": {
       "version": "3.0.5",
-      "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-pipe": {
       "version": "3.0.1",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-merge": "^3.0.0",
@@ -4844,7 +4693,6 @@
     },
     "node_modules/it-pushable": {
       "version": "3.2.3",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "p-defer": "^4.0.0"
@@ -4852,14 +4700,12 @@
     },
     "node_modules/it-stream-types": {
       "version": "2.0.2",
-      "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-to-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
       "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
@@ -4874,7 +4720,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
       "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4910,12 +4755,10 @@
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4931,7 +4774,6 @@
     },
     "node_modules/jsesc": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -4957,7 +4799,6 @@
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.1",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -4967,7 +4808,6 @@
     },
     "node_modules/json-text-sequence": {
       "version": "0.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sovpro/delimited-stream": "^1.1.0"
@@ -5003,12 +4843,10 @@
     },
     "node_modules/just-percentile": {
       "version": "4.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/k-closest": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/keyv": {
@@ -5021,7 +4859,6 @@
     },
     "node_modules/leb128": {
       "version": "0.0.5",
-      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^5.0.0",
@@ -5099,7 +4936,6 @@
     },
     "node_modules/long": {
       "version": "5.2.3",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
@@ -5124,7 +4960,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
       "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-plain-obj": "^2.1.0"
@@ -5135,7 +4970,6 @@
     },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5146,7 +4980,6 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -5326,7 +5159,6 @@
     },
     "node_modules/mri": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -5338,12 +5170,10 @@
     },
     "node_modules/multiformats": {
       "version": "13.3.1",
-      "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -5353,7 +5183,6 @@
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
       "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5372,7 +5201,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
       "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "node-fetch": "*"
@@ -5407,7 +5235,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -5549,7 +5376,6 @@
     },
     "node_modules/one-webcrypto": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -5570,7 +5396,6 @@
     },
     "node_modules/p-defer": {
       "version": "4.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5583,7 +5408,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
       "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-fifo": "^1.0.0",
@@ -5594,7 +5418,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
       "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5632,7 +5455,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
       "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5643,7 +5465,6 @@
     },
     "node_modules/p-queue": {
       "version": "8.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1",
@@ -5658,7 +5479,6 @@
     },
     "node_modules/p-retry": {
       "version": "6.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/retry": "0.12.2",
@@ -5674,7 +5494,6 @@
     },
     "node_modules/p-timeout": {
       "version": "6.1.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -5888,7 +5707,6 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -6082,7 +5900,6 @@
     },
     "node_modules/progress-events": {
       "version": "1.0.1",
-      "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/prop-types": {
@@ -6097,7 +5914,6 @@
     },
     "node_modules/protobufjs": {
       "version": "7.4.0",
-      "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6120,7 +5936,6 @@
     },
     "node_modules/protons-runtime": {
       "version": "5.5.0",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "uint8-varint": "^2.0.2",
@@ -6130,7 +5945,6 @@
     },
     "node_modules/protons-runtime/node_modules/uint8arrays": {
       "version": "5.1.0",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
@@ -6165,7 +5979,6 @@
     },
     "node_modules/rabin-rs": {
       "version": "2.1.0",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/randombytes": {
@@ -6185,7 +5998,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
       "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-defer": "^3.0.0"
@@ -6195,7 +6007,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
       "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6203,7 +6014,6 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -6283,7 +6093,6 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6326,7 +6135,6 @@
     },
     "node_modules/retry": {
       "version": "0.13.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -6379,7 +6187,6 @@
     },
     "node_modules/sade": {
       "version": "1.8.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mri": "^1.1.0"
@@ -6407,7 +6214,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6444,7 +6250,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -6554,7 +6359,6 @@
     },
     "node_modules/sparse-array": {
       "version": "1.3.2",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/split2": {
@@ -6639,7 +6443,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
       "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-iterator": "^1.0.2"
@@ -6647,7 +6450,6 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -6799,8 +6601,7 @@
       }
     },
     "node_modules/stubborn-fs": {
-      "version": "1.2.5",
-      "dev": true
+      "version": "1.2.5"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -6825,7 +6626,6 @@
     },
     "node_modules/sync-multihash-sha2": {
       "version": "1.0.0",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@noble/hashes": "^1.3.1"
@@ -6858,7 +6658,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
@@ -6983,7 +6782,6 @@
     },
     "node_modules/uint8-varint": {
       "version": "2.0.4",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "uint8arraylist": "^2.0.0",
@@ -6992,7 +6790,6 @@
     },
     "node_modules/uint8-varint/node_modules/uint8arrays": {
       "version": "5.1.0",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
@@ -7000,7 +6797,6 @@
     },
     "node_modules/uint8arraylist": {
       "version": "2.4.8",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "uint8arrays": "^5.0.1"
@@ -7008,7 +6804,6 @@
     },
     "node_modules/uint8arraylist/node_modules/uint8arrays": {
       "version": "5.1.0",
-      "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
@@ -7016,7 +6811,6 @@
     },
     "node_modules/uint8arrays": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "multiformats": "^9.4.2"
@@ -7024,7 +6818,6 @@
     },
     "node_modules/uint8arrays/node_modules/multiformats": {
       "version": "9.9.0",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/unbox-primitive": {
@@ -7055,12 +6848,10 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/varint": {
       "version": "6.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/version-guard": {
@@ -7075,14 +6866,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -7090,8 +6879,7 @@
       }
     },
     "node_modules/when-exit": {
-      "version": "2.1.3",
-      "dev": true
+      "version": "2.1.3"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/stats/package.json
+++ b/stats/package.json
@@ -11,10 +11,10 @@
   "devDependencies": {
     "@filecoin-station/spark-stats-db": "^1.0.0",
     "mocha": "^11.0.1",
-    "spark-evaluate": "filecoin-station/spark-evaluate#main",
     "standard": "^17.1.2"
   },
   "dependencies": {
+    "@filecoin-station/spark-evaluate": "^1.0.0",
     "@filecoin-station/spark-stats-db": "^1.0.0",
     "@sentry/node": "^8.48.0",
     "@sentry/profiling-node": "^8.50.0",

--- a/stats/package.json
+++ b/stats/package.json
@@ -9,12 +9,12 @@
     "test": "mocha"
   },
   "devDependencies": {
+    "@filecoin-station/spark-evaluate": "^1.0.4",
     "@filecoin-station/spark-stats-db": "^1.0.0",
     "mocha": "^11.0.1",
     "standard": "^17.1.2"
   },
   "dependencies": {
-    "@filecoin-station/spark-evaluate": "^1.0.0",
     "@filecoin-station/spark-stats-db": "^1.0.0",
     "@sentry/node": "^8.48.0",
     "@sentry/profiling-node": "^8.50.0",


### PR DESCRIPTION
Make spark-evaluate automatically upgradable by installing it via npm.

Closes #288